### PR TITLE
Use string locales SFINT-2448

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -23,9 +23,11 @@ export class Translation {
      * @param translationDictionary Key-Value dictionary that contain all traslation for a language.
      */
     public static register(language: Language, translationDictionary: ILanguageDictionary) {
-        // @ts-ignore
-        String.toLocaleString({
-            [language]: translationDictionary
+        Object.keys(translationDictionary).forEach(key => {
+            String['locales'] = String['locales'] || {};
+            String['locales'][language] = String['locales'][language] || {};
+            String['locales'][language][key] = translationDictionary[key];
         });
+        String['toLocaleString'].call(this, { [language]: String['locales'][language] });
     }
 }

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -24,10 +24,10 @@ export class Translation {
      */
     public static register(language: Language, translationDictionary: ILanguageDictionary) {
         Object.keys(translationDictionary).forEach(key => {
-            String['locales'] = String['locales'] || {};
-            String['locales'][language] = String['locales'][language] || {};
-            String['locales'][language][key] = translationDictionary[key];
+            (String as any)['locales'] = (String as any)['locales'] || {};
+            (String as any)['locales'][language] = (String as any)['locales'][language] || {};
+            (String as any)['locales'][language][key] = translationDictionary[key];
         });
-        String['toLocaleString'].call(this, { [language]: String['locales'][language] });
+        String['toLocaleString'].call(this, { [language]: (String as any)['locales'][language] });
     }
 }

--- a/tests/Utils/translation.spec.ts
+++ b/tests/Utils/translation.spec.ts
@@ -1,0 +1,32 @@
+import { Translation, Language } from '../../src/utils/translation';
+
+describe('Translation', () => {
+    describe('register', () => {
+        it('should register each translation in the String locales', () => {
+            const dict = {
+                1: 'someTest1',
+                2: ''
+            };
+            Translation.register(Language.English, dict);
+
+            Object.keys(dict).forEach(key => {
+                expect(String['locales'][Language.English][key]).toBe(dict[key]);
+                expect(key.toLocaleString()).toBe(dict[key]);
+            });
+            expect(String['locales'][Language.English][3]).toBe(undefined);
+        });
+
+        it('should enable toLocaleString for each registered strings', () => {
+            const dict = {
+                1: 'someTest1',
+                2: ''
+            };
+            Translation.register(Language.English, dict);
+
+            Object.keys(dict).forEach(key => {
+                expect(key.toLocaleString()).toBe(dict[key]);
+            });
+            expect('3'.toLocaleString()).toBe('3');
+        });
+    });
+});

--- a/tests/Utils/translation.spec.ts
+++ b/tests/Utils/translation.spec.ts
@@ -3,23 +3,40 @@ import { Translation, Language } from '../../src/utils/translation';
 describe('Translation', () => {
     describe('register', () => {
         it('should register each translation in the String locales', () => {
-            const dict = {
-                1: 'someTest1',
-                2: ''
+            (String as any)['locales'] = {};
+            (String as any)['locales']['en'] = {};
+            const dict: { [key: string]: string } = {
+                '1': 'someTest1',
+                '2': ''
             };
             Translation.register(Language.English, dict);
 
             Object.keys(dict).forEach(key => {
-                expect(String['locales'][Language.English][key]).toBe(dict[key]);
+                expect((String as any)['locales'][Language.English][key]).toBe(dict[key]);
                 expect(key.toLocaleString()).toBe(dict[key]);
             });
-            expect(String['locales'][Language.English][3]).toBe(undefined);
+            expect((String as any)['locales'][Language.English][3]).toBe(undefined);
+        });
+
+        it('should register each translation in the String locales even when the String locales is not defined yet', () => {
+            (String as any)['locales'] = undefined;
+            const dict: { [key: string]: string } = {
+                '1': 'someTest1',
+                '2': ''
+            };
+            Translation.register(Language.English, dict);
+
+            Object.keys(dict).forEach(key => {
+                expect((String as any)['locales'][Language.English][key]).toBe(dict[key]);
+                expect(key.toLocaleString()).toBe(dict[key]);
+            });
+            expect((String as any)['locales'][Language.English][3]).toBe(undefined);
         });
 
         it('should enable toLocaleString for each registered strings', () => {
-            const dict = {
-                1: 'someTest1',
-                2: ''
+            const dict: { [key: string]: string } = {
+                '1': 'someTest1',
+                '2': ''
             };
             Translation.register(Language.English, dict);
 


### PR DESCRIPTION
This prevent an issue in the interface editor where the registered strings are nuke by an other definition of `toLocaleString` loaded. (Multiple CoveoJsSearch.js loaded)