### PR TITLE
fix(SFINT-2500): Add ts-es5-istanbul-coverage loader

### DIFF
--- a/config/webpack.config.karma.js
+++ b/config/webpack.config.karma.js
@@ -3,21 +3,42 @@ const path = require('path');
 
 // These modifications are required to have proper coverage with karma-coverage-istanbul-reporter.
 webpackConfig.devtool = 'inline-source-map';
-webpackConfig.module.rules.find(rule => rule.loader === 'ts-loader').options.compilerOptions = {
-    module: 'commonjs',
-    inlineSourceMap: true,
-    sourceMap: undefined,
-    outDir: undefined
-};
-webpackConfig.module.rules.push({
-    enforce: 'post',
-    test: /\.ts$/,
-    loader: 'istanbul-instrumenter-loader',
-    exclude: path.resolve('tests/'),
-    query: {
-        esModules: true
+webpackConfig.module.rules = [
+    {
+        test: /\.ts$/,
+        use: [
+            {
+                loader: 'ts-es5-istanbul-coverage'
+            },
+            {
+                loader: 'ts-loader',
+                options: {
+                    configFile: path.resolve('./config/tsconfig.json'),
+                    compilerOptions: {
+                        module: 'commonjs',
+                        inlineSourceMap: true,
+                        sourceMap: undefined,
+                        outDir: undefined
+                    }
+                }
+            }
+        ]
+    },
+    {
+        test: /\.svg$/,
+        loader: 'raw-loader',
+        options: {}
+    },
+    {
+        enforce: 'post',
+        test: /\.ts$/,
+        loader: 'istanbul-instrumenter-loader',
+        exclude: path.resolve('tests/'),
+        query: {
+            esModules: true
+        }
     }
-});
+];
 
 webpackConfig.externals.push({
     'coveo-search-ui-tests': 'CoveoJsSearchTests'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9887,6 +9887,12 @@
                 "glob": "^7.1.2"
             }
         },
+        "ts-es5-istanbul-coverage": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/ts-es5-istanbul-coverage/-/ts-es5-istanbul-coverage-1.0.6.tgz",
+            "integrity": "sha512-1/+nT1m/VCq4OzJ66MVpFr4Hn1rsTRmcDAYaS9oqF1OIfTFe4ARWmarQIQNlnjAfrjLq8x0TyHA0LHgxTPe7mg==",
+            "dev": true
+        },
         "ts-loader": {
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "rimraf": "^2.6.3",
         "sinon": "^7.3.2",
         "string-replace-webpack-plugin": "^0.1.3",
+        "ts-es5-istanbul-coverage": "^1.0.6",
         "ts-loader": "^6.0.0",
         "typescript": "^3.3.0",
         "webpack": "^4.29.6",

--- a/src/components/UserActions/ClickedDocumentList.ts
+++ b/src/components/UserActions/ClickedDocumentList.ts
@@ -87,7 +87,7 @@ export class ClickedDocumentList extends Component {
      * @param bindings Bindings of the Search-UI environment.
      */
     constructor(public element: HTMLElement, public options: IClickedDocumentList, public bindings: IComponentBindings) {
-        super(element, ClickedDocumentList.ID, bindings) /* istanbul ignore next Istanbul issue with next */;
+        super(element, ClickedDocumentList.ID, bindings);
 
         this.options = ComponentOptions.initComponentOptions(element, ClickedDocumentList, options);
 

--- a/src/components/UserActions/QueryList.ts
+++ b/src/components/UserActions/QueryList.ts
@@ -88,7 +88,7 @@ export class QueryList extends Component {
      * @param bindings Bindings of the Search-UI environment.
      */
     constructor(public element: HTMLElement, public options: IQueryListOptions, public bindings: IComponentBindings) {
-        super(element, QueryList.ID, bindings) /* istanbul ignore next Istanbul issue with next */;
+        super(element, QueryList.ID, bindings);
 
         this.options = ComponentOptions.initComponentOptions(element, QueryList, options);
         this.userProfileModel = get(this.root, UserProfileModel) as UserProfileModel;

--- a/src/components/ViewedByCustomer/ViewedByCustomer.ts
+++ b/src/components/ViewedByCustomer/ViewedByCustomer.ts
@@ -44,7 +44,7 @@ export class ViewedByCustomer extends Component {
      * @param bindings Bindings of the Search-UI environment.
      */
     public constructor(public element: HTMLElement, public options: IViewedByCustomerOptions, public bindings: IComponentBindings) {
-        super(element, ViewedByCustomer.ID, bindings) /* istanbul ignore next Issue with Istanbul and super calls*/;
+        super(element, ViewedByCustomer.ID, bindings);
         this.options = ComponentOptions.initComponentOptions(element, ViewedByCustomer, options);
 
         if (this.resolveResult().isUserActionView) {

--- a/src/models/UserProfileModel.ts
+++ b/src/models/UserProfileModel.ts
@@ -70,7 +70,7 @@ export class UserProfileModel extends Model {
      * @param options A set of options necessary for the component creation.
      */
     constructor(element: HTMLElement, public options: IUserProfileModelOptions) {
-        super(element, UserProfileModel.ID, {}) /* istanbul ignore next Istanbul issue with next */;
+        super(element, UserProfileModel.ID, {});
         Assert.isNotUndefined(this.options.restUri);
         Assert.isNotUndefined(this.options.organizationId);
         Assert.isNotUndefined(this.options.searchEndpoint);


### PR DESCRIPTION
This package will add the istanbul ignore statement where they need to be to circumvent the issue with TypeScript transpilation to ES5.
This will only apply when the code is transpiled for unit tests, not for production.
Also remove all the istanbul ignore comments now that they're not needed anymore.
