### PR TITLE
style(SFINT-2506): Change CSS to enforce better vertical alignment

### DIFF
--- a/src/components/ViewedByCustomer/ViewedByCustomer.scss
+++ b/src/components/ViewedByCustomer/ViewedByCustomer.scss
@@ -6,13 +6,16 @@
     font-weight: bold;
     font-size: 14px;
     .viewed-by-customer-icon {
-        vertical-align: middle;
+        vertical-align: baseline;
+        margin-right: 0.5em;
         svg {
             height: 1em;
             width: 1em;
+            vertical-align: middle;
         }
     }
     .viewed-by-customer-label {
-        vertical-align: baseline;
+        vertical-align: middle;
+        line-height: 1em;
     }
 }


### PR DESCRIPTION
Only some CSS fix. The root cause being that Salesforce change the vertical align of all CSS, oddly.
So I specified the alignment of the svg element of the ViewedByCustomer and try to make it look better.
Before:
![image](https://user-images.githubusercontent.com/12366410/63727278-d4283880-c82d-11e9-8dcf-dad1b572ce93.png)

Now: 
![image](https://user-images.githubusercontent.com/12366410/63728280-21f27000-c831-11e9-95f1-7884c892a60f.png)


Before, in Salesforce:
![image](https://user-images.githubusercontent.com/12366410/63727412-3d0fb080-c82e-11e9-9169-dc18bd7e2136.png)

After, in Salesforce:
![image](https://user-images.githubusercontent.com/12366410/63728303-333b7c80-c831-11e9-9d70-4691a12ad8a7.png)

