### PR TITLE
Sfint 2496 - Added falsey check for userId in DocumentClickedList Component

### DIFF
--- a/src/components/UserActions/ClickedDocumentList.ts
+++ b/src/components/UserActions/ClickedDocumentList.ts
@@ -96,6 +96,11 @@ export class ClickedDocumentList extends Component {
 
         this.options = ComponentOptions.initComponentOptions(element, ClickedDocumentList, options);
 
+        if (!this.options.userId) {
+            this.disable();
+            return;
+        }
+
         this.userProfileModel = get(this.root, UserProfileModel) as UserProfileModel;
 
         this.userProfileModel.getActions(this.options.userId).then(actions => {

--- a/src/components/UserActions/QueryList.ts
+++ b/src/components/UserActions/QueryList.ts
@@ -101,6 +101,12 @@ export class QueryList extends Component {
         super(element, QueryList.ID, bindings);
 
         this.options = ComponentOptions.initComponentOptions(element, QueryList, options);
+
+        if (!this.options.userId) {
+            this.disable();
+            return;
+        }
+
         this.userProfileModel = get(this.root, UserProfileModel) as UserProfileModel;
         this.userProfileModel.getActions(this.options.userId).then(actions => {
             this.sortedQueryList = [...actions]

--- a/src/components/UserActions/UserActivity.ts
+++ b/src/components/UserActions/UserActivity.ts
@@ -90,6 +90,12 @@ export class UserActivity extends Component {
         super(element, UserActivity.ID, bindings);
 
         this.options = ComponentOptions.initComponentOptions(element, UserActivity, options);
+
+        if (!this.options.userId) {
+            this.disable();
+            return;
+        }
+
         this.userProfileModel = get(this.root, UserProfileModel) as UserProfileModel;
 
         this.userProfileModel.getActions(this.options.userId).then(actions => {

--- a/tests/components/UserActions/ClickedDocumentList.spec.ts
+++ b/tests/components/UserActions/ClickedDocumentList.spec.ts
@@ -249,6 +249,21 @@ describe('ClickedDocumentList', () => {
         });
     });
 
+    it('Should disable itself when the userId is empty string', () => {
+        let getActionStub: SinonStub<[HTMLElement, ClickedDocumentList], void>;
+        const mock = Mock.advancedComponentSetup<ClickedDocumentList>(
+            ClickedDocumentList,
+            new Mock.AdvancedComponentSetupOptions(null, {userId: ''}, env => {
+                getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                return env;
+            })
+        );
+        return delay(() => {
+            expect(getActionStub.called).toBe(false);
+            expect(mock.cmp.disabled).toBe(true);
+        });
+    });
+
     describe('template', () => {
         it('should use the given template in options', () => {
             sandbox.stub(Initialization, 'automaticallyCreateComponentsInsideResult');

--- a/tests/components/UserActions/ClickedDocumentList.spec.ts
+++ b/tests/components/UserActions/ClickedDocumentList.spec.ts
@@ -1,4 +1,4 @@
-import { createSandbox, SinonSandbox } from 'sinon';
+import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { Mock, Fake } from 'coveo-search-ui-tests';
 import { ClickedDocumentList } from '../../../src/components/UserActions/ClickedDocumentList';
 import { UserProfileModel, UserAction } from '../../../src/models/UserProfileModel';
@@ -231,6 +231,21 @@ describe('ClickedDocumentList', () => {
         return delay(() => {
             expect(mock.cmp.element.childElementCount).toBe(0);
             expect(errorLoggerStub.called).toBe(true);
+        });
+    });
+
+    it('Should disable itself when the userId is falsey', () => {
+        let getActionStub: SinonStub<[HTMLElement, ClickedDocumentList], void>;
+        const mock = Mock.advancedComponentSetup<ClickedDocumentList>(
+            ClickedDocumentList,
+            new Mock.AdvancedComponentSetupOptions(null, {userId: null}, env => {
+                getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                return env;
+            })
+        );
+        return delay(() => {
+            expect(getActionStub.called).toBe(false);
+            expect(mock.cmp.disabled).toBe(true);
         });
     });
 

--- a/tests/components/UserActions/QueryList.spec.ts
+++ b/tests/components/UserActions/QueryList.spec.ts
@@ -1,4 +1,4 @@
-import { createSandbox, SinonSandbox } from 'sinon';
+import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { Mock } from 'coveo-search-ui-tests';
 import { QueryList } from '../../../src/components/UserActions/QueryList';
 import { UserAction } from '../../../src/models/UserProfileModel';
@@ -290,6 +290,36 @@ describe('QueryList', () => {
                 expect(logSearchEventStub.callCount).toBe(1);
                 expect(logSearchEventStub.args[0][0].name).toBe('userActionsSubmit');
                 expect(logSearchEventStub.args[0][0].type).toBe('User Actions');
+            });
+        });
+
+        it('Should disable itself when the userId is falsey', () => {
+            let getActionStub: SinonStub<[HTMLElement, QueryList], void>;
+            const mock = Mock.advancedComponentSetup<QueryList>(
+                QueryList,
+                new Mock.AdvancedComponentSetupOptions(null, {userId: null}, env => {
+                    getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                    return env;
+                })
+            );
+            return delay(() => {
+                expect(getActionStub.called).toBe(false);
+                expect(mock.cmp.disabled).toBe(true);
+            });
+        });
+    
+        it('Should disable itself when the userId is empty string', () => {
+            let getActionStub: SinonStub<[HTMLElement, QueryList], void>;
+            const mock = Mock.advancedComponentSetup<QueryList>(
+                QueryList,
+                new Mock.AdvancedComponentSetupOptions(null, {userId: ''}, env => {
+                    getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                    return env;
+                })
+            );
+            return delay(() => {
+                expect(getActionStub.called).toBe(false);
+                expect(mock.cmp.disabled).toBe(true);
             });
         });
     });

--- a/tests/components/UserActions/UserActivity.spec.ts
+++ b/tests/components/UserActions/UserActivity.spec.ts
@@ -1,4 +1,4 @@
-import { SinonSandbox, createSandbox } from 'sinon';
+import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
 import { UserAction } from '../../../src/models/UserProfileModel';
 import { Mock, Fake } from 'coveo-search-ui-tests';
 import { UserActionType } from '../../../src/rest/UserProfilingEndpoint';
@@ -525,6 +525,36 @@ describe('UserActivity', () => {
 
                 expect(clickElement).not.toBeNull();
                 expect(clickElement.querySelector<HTMLElement>('.coveo-footer').innerText).toMatch(FAKE_CUSTOM_EVENT.raw.origin_level_1);
+            });
+        });
+
+        it('Should disable itself when the userId is falsey', () => {
+            let getActionStub: SinonStub<[HTMLElement, UserActivity], void>;
+            const mock = Mock.advancedComponentSetup<UserActivity>(
+                UserActivity,
+                new Mock.AdvancedComponentSetupOptions(null, {userId: null}, env => {
+                    getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                    return env;
+                })
+            );
+            return delay(() => {
+                expect(getActionStub.called).toBe(false);
+                expect(mock.cmp.disabled).toBe(true);
+            });
+        });
+    
+        it('Should disable itself when the userId is empty string', () => {
+            let getActionStub: SinonStub<[HTMLElement, UserActivity], void>;
+            const mock = Mock.advancedComponentSetup<UserActivity>(
+                UserActivity,
+                new Mock.AdvancedComponentSetupOptions(null, {userId: ''}, env => {
+                    getActionStub = fakeUserProfileModel(env.root, sandbox).getActions;
+                    return env;
+                })
+            );
+            return delay(() => {
+                expect(getActionStub.called).toBe(false);
+                expect(mock.cmp.disabled).toBe(true);
             });
         });
     });


### PR DESCRIPTION
Previously the `DocumentClickedList` component would call the `getActions` method for a `UserProfileModel` with a falsey `userId` value when opening a new chat.

This Pull Request adds a falsey check for `userId`. If falsey, the component is disabled.

Added unit test for the falsey check.

Edit: The scope was expanded to fix the same issue in the `QueryList` component and `UserActivity` component.