### PR TITLE
fix(SFINT-2577): Add karma-webpack-die-hard

### DIFF
--- a/config/webpack.config.karma.js
+++ b/config/webpack.config.karma.js
@@ -1,6 +1,7 @@
-const webpackConfig = require('./webpack.config.js');
 const path = require('path');
+const WebpackKarmaDieHardPlugin = require('webpack-karma-die-hard');
 
+const webpackConfig = require('./webpack.config.js');
 // These modifications are required to have proper coverage with karma-coverage-istanbul-reporter.
 webpackConfig.devtool = 'inline-source-map';
 webpackConfig.module.rules = [
@@ -43,5 +44,12 @@ webpackConfig.module.rules = [
 webpackConfig.externals.push({
     'coveo-search-ui-tests': 'CoveoJsSearchTests'
 });
+
+/**
+ * Plugin for Webpack to ensure errors cause it to quit with a non-zero exit code
+ * when used as a Karma preprocessor with the karma-webpack plugin.
+ * This works around known issues in karma-webpack: https://github.com/webpack-contrib/karma-webpack/issues/66
+ */
+webpackConfig.plugins.push(new WebpackKarmaDieHardPlugin());
 
 module.exports = webpackConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12476,6 +12476,57 @@
                 }
             }
         },
+        "webpack-karma-die-hard": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/webpack-karma-die-hard/-/webpack-karma-die-hard-1.0.4.tgz",
+            "integrity": "sha1-3cBlSNwUTP+rF2CnOjd95xphvfQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
         "webpack-log": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
         "typescript": "^3.3.0",
         "webpack": "^4.29.6",
         "webpack-cli": "^3.2.3",
-        "webpack-dev-server": "^3.2.1"
+        "webpack-dev-server": "^3.2.1",
+        "webpack-karma-die-hard": "^1.0.4"
     },
     "dependencies": {
         "snyk": "^1.203.0"

--- a/tests/components/ResultsFilter/ResultsFilter.spec.ts
+++ b/tests/components/ResultsFilter/ResultsFilter.spec.ts
@@ -2,7 +2,6 @@ import { ResultsFilter, IResultsFilterOptions } from '../../../src/components/Re
 import { Mock, Simulate } from 'coveo-search-ui-tests';
 import { QueryStateModel } from 'coveo-search-ui';
 import { ResultsFilterEvents, IResultsFilterEventArgs } from '../../../src/components/ResultsFilter/Events';
-import { Translation, Language } from '../../../src/utils/translation';
 
 describe('ResultsFilter', () => {
     let filter: Mock.IBasicComponentSetup<ResultsFilter>;

--- a/tests/components/ViewedByCustomer/ViewedByCustomer.spec.ts
+++ b/tests/components/ViewedByCustomer/ViewedByCustomer.spec.ts
@@ -1,8 +1,8 @@
 import { ViewedByCustomer } from '../../../src/Index';
 import { Mock, Fake } from 'coveo-search-ui-tests';
 import { IViewedByCustomerOptions } from '../../../src/components/ViewedByCustomer/ViewedByCustomer';
-import { IQueryResult, Component } from 'coveo-search-ui';
-import { AdvancedComponentSetupOptions, MockEnvironmentBuilder } from 'coveo-search-ui-tests/MockEnvironment';
+import { IQueryResult } from 'coveo-search-ui';
+import { AdvancedComponentSetupOptions } from 'coveo-search-ui-tests/MockEnvironment';
 import { createSandbox, SinonSandbox } from 'sinon';
 
 describe('ViewedByCustomer', () => {


### PR DESCRIPTION
karma-webpack does not bubble up errors and warning properly, so the build would pass even if errors occurs at the transpilation stage.

abstiles/webpack-karma-die-hard is a simple webpack plugin that ensure that when such error occurs karma is properly notified of it. I added it to the webpack config used for our tests.

You can see the result (i.e. a failed build) [here](https://travis-ci.org/coveo/search-ui-extensions/builds/589582061).

I also fixed the transpilation issues in the tests: two TS6133 errors (variable declared but not used or read) and a TS6192 (All imports in import declaration are unused). This fix the issues raised in the aforementioned failed build.