### PR TITLE
doc(SFINT-2611): Use Travis stuff, not shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # search-ui-extensions
 
-![Travis Status](https://img.shields.io/travis/coveo/search-ui-extensions.svg)
+[![Build Status](https://travis-ci.org/coveo/search-ui-extensions.svg?branch=master)](https://travis-ci.org/coveo/search-ui-extensions)
 [![NPM Version](https://img.shields.io/npm/v/coveo-search-ui-extensions.svg)](https://www.npmjs.com/package/coveo-search-ui-extensions)
 [![Coverage Status](https://coveralls.io/repos/github/coveo/search-ui-extensions/badge.svg?branch=master)](https://coveralls.io/github/coveo/search-ui-extensions?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/github/coveo/search-ui-extensions/badge.svg?targetFile=package.json)](https://snyk.io/test/github/coveo/search-ui-extensions?targetFile=package.json)


### PR DESCRIPTION
When you clicked the build status badge, you were redirected to the picture of the badge itself
Now, when you click on it, you are redirected to the Travis of the repo.