### PR TITLE
fix(SFINT-2612): Remove duplicate options in UserActions

### DIFF
--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -56,8 +56,6 @@ export interface IUserActionsOptions {
      * Default: `True`
      */
     viewedByCustomer: Boolean;
-
-    createdBy: string;
 }
 
 /**
@@ -85,8 +83,7 @@ export class UserActions extends Component {
         }),
         viewedByCustomer: ComponentOptions.buildBooleanOption({
             defaultValue: true
-        }),
-        createdBy: ComponentOptions.buildStringOption()
+        })
     };
 
     private static readonly USER_ACTION_OPENED = 'coveo-user-actions-opened';
@@ -277,7 +274,7 @@ export class UserActions extends Component {
         Coveo.$$(this.root).on('buildingQuery', (e, args) => {
             try {
                 args.queryBuilder.userActions = {
-                    tagViewsOfUser: this.options.createdBy
+                    tagViewsOfUser: this.options.userId
                 };
             } catch (e) {
                 this.logger.warn("CreatedBy Email wasn't found", e);

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -422,7 +422,7 @@ describe('UserActions', () => {
         it('should add email to query', () => {
             const mock = Mock.advancedComponentSetup<UserActions>(
                 UserActions,
-                new Mock.AdvancedComponentSetupOptions(null, { userId: 'testUserId', createdBy: 'test@email.com' }, env => {
+                new Mock.AdvancedComponentSetupOptions(null, { userId: 'testUserId' }, env => {
                     fakeUserProfileModel(env.root, sandbox).getActions.returns(new Promise(() => {}));
                     return env;
                 })
@@ -434,7 +434,7 @@ describe('UserActions', () => {
             Coveo.$$(mock.env.root).trigger('buildingQuery', queryArgs);
 
             return delay(() => {
-                expect(queryData.queryBuilder.userActions.tagViewsOfUser).toBe('test@email.com');
+                expect(queryData.queryBuilder.userActions.tagViewsOfUser).toBe('testUserId');
             });
         });
 


### PR DESCRIPTION
@jeremierobert-coveo pointed out that we don't need another options for the viewedBy and can use the userId. This does that.