### PR TITLE
Added type button to the More/Less button in expandable list

### DIFF
--- a/src/components/UserActions/ExpandableList.ts
+++ b/src/components/UserActions/ExpandableList.ts
@@ -83,6 +83,7 @@ export class ExpandableList<T> {
 
     private buildMoreButton() {
         const button = document.createElement('button');
+        button.type = 'button';
         button.classList.add('coveo-more-less');
         button.addEventListener('click', this.toggleExpansion.bind(this));
         this.button = button;

--- a/tests/components/UserActions/ExpandableList.spec.ts
+++ b/tests/components/UserActions/ExpandableList.spec.ts
@@ -69,7 +69,7 @@ describe('ExpandableList', () => {
     });
 
     describe('show more/less button', () => {
-        it('should start with a "Show More" text', () => {
+        it('should start with a "Show More" text and be of type button', () => {
             const list = new ExpandableList(document.createElement('div'), TEST_ITEM_LIST, {
                 transform: spanItemGenerator,
                 maximumItemsShown: 10,
@@ -81,6 +81,7 @@ describe('ExpandableList', () => {
 
                 expect(el).not.toBeNull();
                 expect(el.innerText).toBe('Show More');
+                expect(el.getAttribute('type')).toBe('button');
             });
         });
 


### PR DESCRIPTION
Without the `type=button`  attribute, the default behaviour of the button is to submit the parent form, if there is any. That was a problem in ServiceNow since the whole page is a huge form, clicking on Show More/Less would submit the page and redirect the user. 

SNOW-240