### PR TITLE
fix(SFINT-2851): BREAKING Insert ViewedByCustomer in a new row

### DIFF
--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -288,20 +288,10 @@ export class UserActions extends Component {
             if (Boolean(args.item.getElementsByClassName('CoveoViewedByCustomer').length)) {
                 return;
             }
-            const viewedByCustomerRow = document.createElement('div');
-            viewedByCustomerRow.classList.add('coveo-result-row');
-
-            const viewedByCustomerCell = document.createElement('div');
-            viewedByCustomerCell.classList.add('coveo-result-cell');
-
-            const viewedByCustomerElement = document.createElement('span');
-            new ViewedByCustomer(viewedByCustomerElement, undefined, this.bindings, args.result);
-
-            viewedByCustomerCell.appendChild(viewedByCustomerElement);
-            viewedByCustomerRow.appendChild(viewedByCustomerCell);
-
             const resultLastRow = '.coveo-result-row:last-child';
-            args.item.querySelector(resultLastRow).parentNode.appendChild(viewedByCustomerElement);
+            args.item
+                .querySelector(resultLastRow)
+                .parentNode.appendChild(ViewedByCustomer.getViewedByCustomerResultRowDom(this.bindings, args.result));
         });
     }
 

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -288,10 +288,20 @@ export class UserActions extends Component {
             if (Boolean(args.item.getElementsByClassName('CoveoViewedByCustomer').length)) {
                 return;
             }
+            const viewedByCustomerRow = document.createElement('div');
+            viewedByCustomerRow.classList.add('coveo-result-row');
+
+            const viewedByCustomerCell = document.createElement('div');
+            viewedByCustomerCell.classList.add('coveo-result-cell');
+
             const viewedByCustomerElement = document.createElement('span');
             new ViewedByCustomer(viewedByCustomerElement, undefined, this.bindings, args.result);
-            const resultLastRow = '.coveo-result-row:last-child .coveo-result-cell';
-            args.item.querySelector(resultLastRow).appendChild(viewedByCustomerElement);
+
+            viewedByCustomerCell.appendChild(viewedByCustomerElement);
+            viewedByCustomerRow.appendChild(viewedByCustomerCell);
+
+            const resultLastRow = '.coveo-result-row:last-child';
+            args.item.querySelector(resultLastRow).parentNode.appendChild(viewedByCustomerElement);
         });
     }
 

--- a/src/components/ViewedByCustomer/ViewedByCustomer.ts
+++ b/src/components/ViewedByCustomer/ViewedByCustomer.ts
@@ -83,6 +83,27 @@ export class ViewedByCustomer extends Component {
         labelElement.innerText = this.options.label;
         this.element.appendChild(labelElement);
     }
+
+    /**
+     * Generate a ViewedByCustomer in a preformated Dom ready to be inserted in a result
+     * @param bindings bindings to be used by the {@link ViewedByCustomer}
+     * @param result result to be used by the {@link ViewedByCustomer}
+     */
+    public static getViewedByCustomerResultRowDom(bindings: IComponentBindings, result: IQueryResult): HTMLElement {
+        const viewedByCustomerRow = document.createElement('div');
+        viewedByCustomerRow.classList.add('coveo-result-row');
+
+        const viewedByCustomerCell = document.createElement('div');
+        viewedByCustomerCell.classList.add('coveo-result-cell');
+
+        const viewedByCustomerElement = document.createElement('span');
+        new ViewedByCustomer(viewedByCustomerElement, undefined, bindings, result);
+
+        viewedByCustomerCell.appendChild(viewedByCustomerElement);
+        viewedByCustomerRow.appendChild(viewedByCustomerCell);
+
+        return viewedByCustomerRow;
+    }
 }
 
 Initialization.registerAutoCreateComponent(ViewedByCustomer);

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -554,12 +554,16 @@ describe('UserActions', () => {
 
     describe('ViewedByCustomer', () => {
         let result: IQueryResult;
+        let resultElementFrame: HTMLElement;
         let resultElementRow: HTMLElement;
         let resultElementCol: HTMLElement;
         let viewedByCustomerOption: Boolean;
 
         beforeEach(() => {
             result = Fake.createFakeResult();
+
+            resultElementFrame = document.createElement('div');
+            resultElementFrame.classList.add('coveo-result-frame');
 
             resultElementRow = document.createElement('div');
             resultElementRow.classList.add('coveo-result-row');
@@ -568,6 +572,7 @@ describe('UserActions', () => {
             resultElementCol.classList.add('coveo-result-cell');
 
             resultElementRow.appendChild(resultElementCol);
+            resultElementFrame.appendChild(resultElementRow);
         });
 
         describe('if the viewedByCustomer option is true', () => {
@@ -584,12 +589,12 @@ describe('UserActions', () => {
                     })
                 );
 
-                const resultArgs = { result: result, item: resultElementRow };
+                const resultArgs = { result: result, item: resultElementFrame };
                 Coveo.$$(mock.env.root).trigger(ResultListEvents.newResultDisplayed, resultArgs);
 
                 return delay(() => {
                     expect(mock.cmp.options.viewedByCustomer).toBe(true);
-                    expect(resultElementRow.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
+                    expect(resultElementFrame.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
                 });
             });
 
@@ -602,13 +607,13 @@ describe('UserActions', () => {
                     })
                 );
 
-                resultElementRow.querySelector('.coveo-result-cell').classList.add('CoveoViewedByCustomer');
+                resultElementFrame.querySelector('.coveo-result-cell').classList.add('CoveoViewedByCustomer');
 
-                const resultArgs = { result: result, item: resultElementRow };
+                const resultArgs = { result: result, item: resultElementFrame };
                 Coveo.$$(mock.env.root).trigger(ResultListEvents.newResultDisplayed, resultArgs);
 
                 return delay(() => {
-                    expect(resultElementRow.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
+                    expect(resultElementFrame.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
                 });
             });
         });
@@ -627,12 +632,12 @@ describe('UserActions', () => {
                     })
                 );
 
-                const resultArgs = { result: result, item: resultElementRow };
+                const resultArgs = { result: result, item: resultElementFrame };
                 Coveo.$$(mock.env.root).trigger(ResultListEvents.newResultDisplayed, resultArgs);
 
                 return delay(() => {
                     expect(mock.cmp.options.viewedByCustomer).toBe(false);
-                    expect(resultElementRow.getElementsByClassName('CoveoViewedByCustomer').length).toBe(0);
+                    expect(resultElementFrame.getElementsByClassName('CoveoViewedByCustomer').length).toBe(0);
                 });
             });
 
@@ -645,15 +650,15 @@ describe('UserActions', () => {
                     })
                 );
 
-                resultElementRow.querySelector('.coveo-result-cell').classList.add('CoveoViewedByCustomer');
+                resultElementFrame.querySelector('.coveo-result-cell').classList.add('CoveoViewedByCustomer');
 
-                expect(resultElementRow.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
+                expect(resultElementFrame.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
 
-                const resultArgs = { result: result, item: resultElementRow };
+                const resultArgs = { result: result, item: resultElementFrame };
                 Coveo.$$(mock.env.root).trigger(ResultListEvents.newResultDisplayed, resultArgs);
 
                 return delay(() => {
-                    expect(resultElementRow.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
+                    expect(resultElementFrame.getElementsByClassName('CoveoViewedByCustomer').length).toBe(1);
                 });
             });
         });

--- a/tests/components/ViewedByCustomer/ViewedByCustomer.spec.ts
+++ b/tests/components/ViewedByCustomer/ViewedByCustomer.spec.ts
@@ -116,4 +116,15 @@ describe('ViewedByCustomer', () => {
             ).toBe(true);
         });
     });
+
+    describe('getViewedByCustomerResultRowDom', () => {
+        it('should return a well constructed dom', () => {
+            const dom = ViewedByCustomer.getViewedByCustomerResultRowDom(new Mock.MockEnvironmentBuilder().getBindings(), Fake.createFakeResult());
+            expect(dom.className).toBe('coveo-result-row');
+            expect(dom.childElementCount).toBe(1);
+            expect(dom.firstElementChild.className).toBe('coveo-result-cell');
+            expect(dom.firstElementChild.childElementCount).toBe(1);
+            expect(dom.firstElementChild.firstElementChild.className).toBe('CoveoViewedByCustomer');
+        });
+    });
 });


### PR DESCRIPTION
Jira: https://coveord.atlassian.net/browse/SFINT-2851

### The issue

If the last cell/row of the result is already quite full, the Viewed By Customer would break in two lines and that didn't render very well.

### Previous behavior

When 'auto-appending' the ViewedByCustomer in the result, append the ViewedByCustomer in the first cell of the last row of the result frame.

### New behavior

When 'auto-appending' the ViewedByCustomer in the result, find the last row of the result row and create a new 'sibling' row in which there's a cell that include the ViewedByCustomer.

### Screenshot
Top, before. Bottom, after.
![image](https://user-images.githubusercontent.com/12366410/73210124-9cdcf100-4117-11ea-9625-8ed12d082d7b.png)


### Tests

- [X] UT
- [X] SAN Check
