### PR TITLE
Changed default UA type on CopyClipboard [SFINT-3033]

### DIFF
--- a/src/components/CopyToClipboard/CopyToClipboard.ts
+++ b/src/components/CopyToClipboard/CopyToClipboard.ts
@@ -71,7 +71,7 @@ export class CopyToClipboard extends ResultAction {
     }
 
     protected doAction() {
-        this.usageAnalytics.logClickEvent({ name: 'copyToClipboard', type: 'Click' }, {}, this.result, this.element);
+        this.usageAnalytics.logClickEvent({ name: 'copyToClipboard', type: 'resultAction' }, {}, this.result, this.element);
         this.copyToClipboard(StringUtils.buildStringTemplateFromResult(this.options.template, this.result));
     }
 


### PR DESCRIPTION
Changed default UA type on CopyClipboard from "click" to "resultAction" to match the others.