### PR TITLE
feat(SFINT-3167): Add ActionButton Component

### DIFF
--- a/pages/action_button.html
+++ b/pages/action_button.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, height=device-height" />
+        <title>Development - Action Button</title>
+        <link rel="stylesheet" href="../css/CoveoFullSearch.css" />
+        <link rel="stylesheet" href="../css/CoveoJsSearchExtensions.css" />
+        <script src="../js/CoveoJsSearch.Lazy.js"></script>
+        <script src="../commonjs/CoveoJsSearchExtensions.js"></script>
+        <script>
+            let attachedIds = [];
+            document.addEventListener('DOMContentLoaded', function() {
+                Coveo.SearchEndpoint.configureSampleEndpointV2();
+                Coveo.init(document.body, {});
+            });
+        </script>
+    </head>
+
+    <body id="search" class="CoveoSearchInterface" data-enable-history="false" style="padding: 1em;">
+        <span class="CoveoAnalytics"></span>
+        <div class="coveo-tab-section">
+            <a class="CoveoTab" data-id="All" data-caption="All Content"></a>
+        </div>
+        <div class="coveo-search-section">
+            <div class="CoveoSearchbox" data-enable-omnibox="true"></div>
+        </div>
+
+        <div>
+            <h2>Button with icon only</h2>
+            <br />
+            <button
+                class="CoveoActionButton"
+                data-icon='&lt;svg width=".5em" height=".5em" viewBox="0 0 20 20"&gt;&lt;path d="M4 5h7v1H4V5m0 3h7v1H4V8m0 3h7v1H4v-1"&gt;&lt;/path&gt;&lt;path d="M15 1c.009-.525.066-1-1-1H1.002c-.651 0-1 .33-1 1v15c0 .66.351 1 1 1H3v2c.075.546.383 1 1 1h13c.718 0 1-.295 1-1V3c.001-.468-.406-.99-1-1h-2V1M2 15V2h11v13H2m14 3H5v-.995L14 17c.5.005.976-.428 1-1l.021-12H16v14"&gt;&lt;/path&gt;&lt;/svg&gt;'
+            ></button>
+        </div>
+
+        <div>
+            <h2>Button with icon and text</h2>
+            <br />
+            <button
+                class="CoveoActionButton"
+                data-title="The Text"
+                data-icon='&lt;svg width=".5em" height=".5em" viewBox="0 0 20 20"&gt;&lt;path d="M4 5h7v1H4V5m0 3h7v1H4V8m0 3h7v1H4v-1"&gt;&lt;/path&gt;&lt;path d="M15 1c.009-.525.066-1-1-1H1.002c-.651 0-1 .33-1 1v15c0 .66.351 1 1 1H3v2c.075.546.383 1 1 1h13c.718 0 1-.295 1-1V3c.001-.468-.406-.99-1-1h-2V1M2 15V2h11v13H2m14 3H5v-.995L14 17c.5.005.976-.428 1-1l.021-12H16v14"&gt;&lt;/path&gt;&lt;/svg&gt;'
+            ></button>
+        </div>
+
+        <div>
+            <h2>Button with text only</h2>
+            <br />
+            <button class="CoveoActionButton" data-title="The Text"></button>
+        </div>
+
+        <div>
+            <h2>Multiple buttons</h2>
+            <br />
+
+            <div style="display: flex;">
+                <button class="CoveoActionButton" data-title="First"></button>
+                <button class="CoveoActionButton" data-title="Second"></button>
+                <button class="CoveoActionButton" data-title="Third"></button>
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,5 +1,6 @@
 // This entry point defines all the components that are included in the extensions.
 
+export { ActionButton } from './components/ActionButton/ActionButton';
 export { AttachResult } from './components/AttachResult/AttachResult';
 export { UserActivity } from './components/UserActions/UserActivity';
 export { UserActions } from './components/UserActions/UserActions';

--- a/src/components/ActionButton/ActionButton.scss
+++ b/src/components/ActionButton/ActionButton.scss
@@ -6,8 +6,10 @@ $primary-color-light: #e5e5e5;
 $primary-color-dark: #4a4a4a;
 $accent-color: $calypso;
 
+$button-size: 36px;
+
 button.CoveoActionButton.coveo-actionbutton {
-    height: 36px;
+    height: $button-size;
     border: solid 2px $primary-color-light;
     border-radius: 3px;
     background-color: $primary-color-lightest;
@@ -19,12 +21,12 @@ button.CoveoActionButton.coveo-actionbutton {
 }
 
 .CoveoActionButton {
-    &:not(.coveo-actionbutton-icon) {
+    &:not(.coveo-actionbutton-icononly) {
         padding: 0 16px;
     }
 
-    &.coveo-actionbutton-icon {
-        width: 36px;
+    &.coveo-actionbutton-icononly {
+        width: $button-size;
     }
 
     .coveo-actionbutton_icon {

--- a/src/components/ActionButton/ActionButton.scss
+++ b/src/components/ActionButton/ActionButton.scss
@@ -1,7 +1,10 @@
+@import '../../sass/Variables.scss';
+
 $primary-color-lightest: #ffffff;
+$primary-color-lightest-hover: whitesmoke;
 $primary-color-light: #e5e5e5;
 $primary-color-dark: #4a4a4a;
-$accent-color: #1d4f76;
+$accent-color: $calypso;
 
 button.CoveoActionButton.coveo-actionbutton {
     height: 36px;
@@ -44,9 +47,11 @@ button.CoveoActionButton.coveo-actionbutton {
     }
 }
 
-.CoveoActionButton.coveo-actionbutton:hover {
+.CoveoActionButton.coveo-actionbutton:hover,
+.CoveoActionButton.coveo-actionbutton:active {
     & {
         color: $accent-color;
+        background-color: $primary-color-lightest-hover;
     }
 
     .coveo-actionbutton_icon svg {

--- a/src/components/ActionButton/ActionButton.scss
+++ b/src/components/ActionButton/ActionButton.scss
@@ -1,0 +1,55 @@
+$primary-color-lightest: #ffffff;
+$primary-color-light: #e5e5e5;
+$primary-color-dark: #4a4a4a;
+$accent-color: #1d4f76;
+
+button.CoveoActionButton.coveo-actionbutton {
+    height: 36px;
+    border: solid 2px $primary-color-light;
+    border-radius: 3px;
+    background-color: $primary-color-lightest;
+    color: $primary-color-dark;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+}
+
+.CoveoActionButton {
+    &:not(.coveo-actionbutton-icon) {
+        padding: 0 16px;
+    }
+
+    &.coveo-actionbutton-icon {
+        width: 36px;
+    }
+
+    .coveo-actionbutton_icon {
+        line-height: 0;
+        font-size: 16px;
+
+        svg {
+            height: 1em;
+            width: 1em;
+            fill: $primary-color-dark;
+        }
+
+        + .coveo-actionbutton_title {
+            margin-left: 8px;
+        }
+    }
+
+    + .coveo-actionbutton {
+        margin-left: 5px;
+    }
+}
+
+.CoveoActionButton.coveo-actionbutton:hover {
+    & {
+        color: $accent-color;
+    }
+
+    .coveo-actionbutton_icon svg {
+        fill: $accent-color;
+    }
+}

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -62,7 +62,16 @@ export class ActionButton extends Component {
          * <button class='CoveoActionButton' data-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
          * ```
          */
-        icon: ComponentOptions.buildStringOption()
+        icon: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the handler called when the button is clicked.
+         *
+         * Default is `null`.
+         *
+         * This option must be set in JavaScript when initializing the component.
+         */
+        click: ComponentOptions.buildCustomOption(s => null)
     };
 
     constructor(public element: HTMLElement, public options: IActionButtonOptions, public bindings?: IResultsComponentBindings) {

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -71,7 +71,7 @@ export class ActionButton extends Component {
          *
          * This option must be set in JavaScript when initializing the component.
          */
-        click: ComponentOptions.buildCustomOption(s => null)
+        click: ComponentOptions.buildCustomOption(s => null, { required: true })
     };
 
     constructor(public element: HTMLElement, public options: IActionButtonOptions, public bindings?: IResultsComponentBindings) {
@@ -88,8 +88,6 @@ export class ActionButton extends Component {
 
         if (this.options.click) {
             Coveo.$$(element).on('click', () => this.options.click());
-        } else {
-            console.warn('The ActionButton has no click handler. Did you forget to set the component click option?');
         }
     }
 

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -57,7 +57,7 @@ export class ActionButton extends Component {
         this.element.classList.add('coveo-actionbutton');
 
         if (this.options.icon && !this.options.title) {
-            this.element.classList.add('coveo-actionbutton-icon');
+            this.element.classList.add('coveo-actionbutton-icononly');
         }
     }
 

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -7,6 +7,13 @@ export interface IActionButtonOptions {
     click?: () => void;
 }
 
+/**
+ * The _ActionButton_ component is a simple button allowing to show an icon, text, and tooltip.
+ *
+ * ```html
+ * <button class='CoveoActionButton'></button>
+ * ```
+ */
 export class ActionButton extends Component {
     static ID = 'ActionButton';
 
@@ -15,10 +22,46 @@ export class ActionButton extends Component {
      * @componentOptions
      */
     static options: IActionButtonOptions = {
+        /**
+         * Specifies the button label. The text is displayed on a single line, next to the icon.
+         *
+         * Default is the empty string.
+         *
+         * ```html
+         * <button class='CoveoActionButton' data-title='My Button'></button>
+         * ```
+         */
         title: ComponentOptions.buildStringOption(),
 
+        /**
+         * Specifies the button tooltip text.
+         *
+         * Default is the empty string.
+         *
+         * ```html
+         * <button class='CoveoActionButton' data-tooltip='My button tooltip'></button>
+         * ```
+         */
         tooltip: ComponentOptions.buildStringOption(),
 
+        /**
+         * Specifies the button SVG icon.
+         * Note: The SVG markup has to be HTML encoded when set using the HTML attributes.
+         *
+         * Default is the empty string.
+         *
+         * For example, with this SVG markup:
+         *
+         * ```xml
+         * <svg width="1em" height="1em">...</svg>
+         * ```
+         *
+         * The attribute would be set like this:
+         *
+         * ```html
+         * <button class='CoveoActionButton' data-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * ```
+         */
         icon: ComponentOptions.buildStringOption()
     };
 

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -79,6 +79,8 @@ export class ActionButton extends Component {
 
         if (this.options.click) {
             Coveo.$$(element).on('click', () => this.options.click());
+        } else {
+            console.warn('The ActionButton has no click handler. Did you forget to set the component click option?');
         }
     }
 

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -1,0 +1,91 @@
+import { Component, ComponentOptions, IResultsComponentBindings, Initialization } from 'coveo-search-ui';
+
+export interface IActionButtonOptions {
+    title?: string;
+    tooltip?: string;
+    icon?: string;
+    click?: () => void;
+}
+
+export class ActionButton extends Component {
+    static ID = 'ActionButton';
+
+    /**
+     * The possible options for _ActionButton_.
+     * @componentOptions
+     */
+    static options: IActionButtonOptions = {
+        title: ComponentOptions.buildStringOption(),
+
+        tooltip: ComponentOptions.buildStringOption(),
+
+        icon: ComponentOptions.buildStringOption()
+    };
+
+    constructor(public element: HTMLElement, public options: IActionButtonOptions, public bindings?: IResultsComponentBindings) {
+        super(element, ActionButton.ID, bindings);
+
+        this.options = ComponentOptions.initComponentOptions(element, ActionButton, options);
+
+        if (this.options.icon || this.options.title) {
+            this.render();
+        } else {
+            console.warn('The action button cannot render since no icon nor title is defined.');
+            Coveo.$$(this.element).hide();
+        }
+
+        if (this.options.click) {
+            Coveo.$$(element).on('click', () => this.options.click());
+        }
+    }
+
+    protected render(): void {
+        this.applyButtonStyles();
+
+        if (this.options.icon) {
+            this.appendIcon();
+        }
+        if (this.options.title) {
+            this.appendTitle();
+        }
+        if (this.options.tooltip) {
+            this.appendTooltip();
+        }
+    }
+
+    protected applyButtonStyles(): void {
+        this.element.classList.add('coveo-actionbutton');
+
+        if (this.options.icon && !this.options.title) {
+            this.element.classList.add('coveo-actionbutton-icon');
+        }
+    }
+
+    protected createIconElement(): HTMLElement {
+        const iconElement = document.createElement('span');
+        iconElement.classList.add('coveo-icon', 'coveo-actionbutton_icon');
+        iconElement.innerHTML = this.options.icon;
+        return iconElement;
+    }
+
+    protected createTitleElement(): HTMLElement {
+        const titleElement = document.createElement('span');
+        titleElement.classList.add('coveo-actionbutton_title');
+        titleElement.innerText = this.options.title;
+        return titleElement;
+    }
+
+    private appendIcon(): void {
+        this.element.appendChild(this.createIconElement());
+    }
+
+    private appendTitle(): void {
+        this.element.appendChild(this.createTitleElement());
+    }
+
+    private appendTooltip(): void {
+        this.element.title = this.options.tooltip;
+    }
+}
+
+Initialization.registerAutoCreateComponent(ActionButton);

--- a/src/sass/Index.scss
+++ b/src/sass/Index.scss
@@ -1,3 +1,4 @@
+@import '../components/ActionButton/ActionButton.scss';
 @import '../components/AttachResult/AttachResult.scss';
 @import '../components/UserActions/UserActions.scss';
 @import '../components/ViewedByCustomer/ViewedByCustomer.scss';

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -1,0 +1,120 @@
+import { createSandbox, SinonSandbox, SinonSpy, spy } from 'sinon';
+import { Mock } from 'coveo-search-ui-tests';
+import { ActionButton, IActionButtonOptions } from '../../../src/components/ActionButton/ActionButton';
+import * as icons from '../../../src/utils/icons';
+
+describe('ActionButton', () => {
+    let sandbox: SinonSandbox;
+    let options: IActionButtonOptions;
+    let testSubject: ActionButton;
+
+    let appendIconSpy: SinonSpy;
+    let appendTitleSpy: SinonSpy;
+    let appendTooltipSpy: SinonSpy;
+
+    beforeAll(() => {
+        sandbox = createSandbox();
+    });
+
+    beforeEach(() => {
+        options = {
+            title: 'a default title',
+            tooltip: 'a default tooltip',
+            icon: icons.copy
+        };
+
+        testSubject = createActionButton(options);
+
+        appendIconSpy = sandbox.spy(<any>ActionButton.prototype, 'appendIcon');
+        appendTitleSpy = sandbox.spy(<any>ActionButton.prototype, 'appendTitle');
+        appendTooltipSpy = sandbox.spy(<any>ActionButton.prototype, 'appendTooltip');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('with click option', () => {
+        let clickHandlerSpy: SinonSpy;
+
+        beforeEach(() => {
+            clickHandlerSpy = spy();
+            options.click = clickHandlerSpy;
+            testSubject = createActionButton(options);
+        });
+
+        it('should call the handler when clicking the button', () => {
+            testSubject.element.dispatchEvent(new Event('click', {}));
+
+            expect(clickHandlerSpy.called).toBeTrue();
+        });
+    });
+
+    describe('without icon and title', () => {
+        let renderSpy: SinonSpy;
+
+        beforeEach(() => {
+            renderSpy = sandbox.spy(<any>ActionButton.prototype, 'render');
+            options.title = '';
+            options.icon = '';
+
+            testSubject = createActionButton(options);
+        });
+
+        it('should not render the button', () => {
+            expect(renderSpy.called).toBeFalse();
+        });
+    });
+
+    [
+        {
+            optionName: 'title',
+            optionValue: 'some title',
+            getSpy: () => appendTitleSpy
+        },
+        {
+            optionName: 'icon',
+            optionValue: icons.copy,
+            getSpy: () => appendIconSpy
+        },
+        {
+          optionName: 'tooltip',
+          optionValue: 'Some Tooltip',
+          getSpy: () => appendTooltipSpy
+        },
+    ].forEach(testCase => {
+        describe(`with empty ${testCase.optionName} option`, () => {
+            beforeEach(() => {
+              setOption(testCase.optionName, null);
+              testSubject = createActionButton(options);
+            });
+
+            it(`should not include the ${testCase.optionName}`, () => {
+                expect(testCase.getSpy().called).toBeFalse();
+            });
+        });
+
+        describe(`with ${testCase.optionName} option`, () => {
+            beforeEach(() => {
+                setOption(testCase.optionName, testCase.optionValue);
+                testSubject = createActionButton(options);
+            });
+
+            it(`should include the ${testCase.optionName}`, () => {
+                expect(testCase.getSpy().called).toBeTrue();
+            });
+        });
+    });
+
+    const createActionButton = (options: IActionButtonOptions) => {
+        const element = document.createElement('button');
+        const componentSetup = Mock.advancedComponentSetup<ActionButton>(ActionButton, new Mock.AdvancedComponentSetupOptions(element, options));
+
+        return componentSetup.cmp;
+    };
+
+    const setOption = (optionName: string, optionValue: any) => {
+      const dictOptions = options as { [key: string]: any };
+      dictOptions[optionName] = optionValue;
+    }
+});

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -78,15 +78,15 @@ describe('ActionButton', () => {
             getSpy: () => appendIconSpy
         },
         {
-          optionName: 'tooltip',
-          optionValue: 'Some Tooltip',
-          getSpy: () => appendTooltipSpy
-        },
+            optionName: 'tooltip',
+            optionValue: 'Some Tooltip',
+            getSpy: () => appendTooltipSpy
+        }
     ].forEach(testCase => {
         describe(`with empty ${testCase.optionName} option`, () => {
             beforeEach(() => {
-              setOption(testCase.optionName, null);
-              testSubject = createActionButton(options);
+                setOption(testCase.optionName, null);
+                testSubject = createActionButton(options);
             });
 
             it(`should not include the ${testCase.optionName}`, () => {
@@ -114,7 +114,7 @@ describe('ActionButton', () => {
     };
 
     const setOption = (optionName: string, optionValue: any) => {
-      const dictOptions = options as { [key: string]: any };
-      dictOptions[optionName] = optionValue;
-    }
+        const dictOptions = options as { [key: string]: any };
+        dictOptions[optionName] = optionValue;
+    };
 });


### PR DESCRIPTION
This PR adds the _ActionButton_ component. This component is meant to be a reusable button component displaying an icon and/or text with a tooltip.

The button looks like this:

![action-button](https://user-images.githubusercontent.com/10946843/83642767-3f512900-a57d-11ea-8889-48de3ff52249.png)

Hovering the button looks like this:

![action-button-icon_hover](https://user-images.githubusercontent.com/10946843/83642825-5263f900-a57d-11ea-829e-884aaa8dd7b3.png)
![action-button-icon-text_hover](https://user-images.githubusercontent.com/10946843/83642838-54c65300-a57d-11ea-8b2e-7a7248501868.png)
![action-button-text_hover](https://user-images.githubusercontent.com/10946843/83642844-56901680-a57d-11ea-93a9-a4701070f63d.png)
