### PR TITLE
fix(SFINT-3248): Replace prepend by insertBefore

### DIFF
--- a/src/components/UserActions/UserActivity.ts
+++ b/src/components/UserActions/UserActivity.ts
@@ -297,7 +297,7 @@ export class UserActivity extends Component {
 
         const titleSection = this.buildTitleSection(action);
         titleSection.querySelector(`.${ACTIVITY_TITLE_CLASS}`).remove();
-        titleSection.prepend(titleElem);
+        titleSection.insertBefore(titleElem, titleSection.firstChild);
 
         const dataElement = document.createElement('div');
         dataElement.classList.add(DATA_CLASS);


### PR DESCRIPTION
prepend is not supported by antiquated and/or restrictive tech and browser, namely IE11 and LockerService.
insertBefore works pretty much everywhere.

No change in behavior, nor logic, therefore existing tests are actually testing the changes.
If we'd like to test the aforementioned limiters, this IMO should be done in another story.

Source:
https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend
https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore in particular example 3.