### PR TITLE
feat(sfint-3272): Add ToggleActionButton component

### DIFF
--- a/pages/toggle_action_button.html
+++ b/pages/toggle_action_button.html
@@ -31,8 +31,8 @@
             <br />
             <button
                 class="CoveoToggleActionButton"
-                data-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
-                data-tooltip="Normal tooltip"
+                data-deactivated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
+                data-deactivated-tooltip="Normal tooltip"
                 data-activated-tooltip="Activated tooltip"
                 data-activated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
             ></button>

--- a/pages/toggle_action_button.html
+++ b/pages/toggle_action_button.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, height=device-height" />
+        <title>Development - Toggle Action Button</title>
+        <link rel="stylesheet" href="../css/CoveoFullSearch.css" />
+        <link rel="stylesheet" href="../css/CoveoJsSearchExtensions.css" />
+        <script src="../js/CoveoJsSearch.Lazy.js"></script>
+        <script src="../commonjs/CoveoJsSearchExtensions.js"></script>
+        <script>
+            let attachedIds = [];
+            document.addEventListener('DOMContentLoaded', function() {
+                Coveo.SearchEndpoint.configureSampleEndpointV2();
+                Coveo.init(document.body, {});
+            });
+        </script>
+    </head>
+
+    <body id="search" class="CoveoSearchInterface" data-enable-history="false" style="padding: 1em;">
+        <span class="CoveoAnalytics"></span>
+        <div class="coveo-tab-section">
+            <a class="CoveoTab" data-id="All" data-caption="All Content"></a>
+        </div>
+        <div class="coveo-search-section">
+            <div class="CoveoSearchbox" data-enable-omnibox="true"></div>
+        </div>
+
+        <div>
+            <h2>Toggle Button</h2>
+            <br />
+            <button
+                class="CoveoToggleActionButton"
+                data-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
+                data-tooltip="Normal tooltip"
+                data-activated-tooltip="Activated tooltip"
+                data-activated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
+            ></button>
+        </div>
+    </body>
+</html>

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,6 +1,7 @@
 // This entry point defines all the components that are included in the extensions.
 
 export { ActionButton } from './components/ActionButton/ActionButton';
+export { ToggleActionButton } from './components/ActionButton/ToggleActionButton';
 export { AttachResult } from './components/AttachResult/AttachResult';
 export { UserActivity } from './components/UserActions/UserActivity';
 export { UserActions } from './components/UserActions/UserActions';

--- a/src/components/ActionButton/ActionButton.scss
+++ b/src/components/ActionButton/ActionButton.scss
@@ -1,10 +1,7 @@
-@import '../../sass/Variables.scss';
-
 $primary-color-lightest: #ffffff;
 $primary-color-lightest-hover: whitesmoke;
 $primary-color-light: #e5e5e5;
 $primary-color-dark: #4a4a4a;
-$accent-color: $calypso;
 
 $button-size: 36px;
 
@@ -52,11 +49,11 @@ button.CoveoActionButton.coveo-actionbutton {
 .CoveoActionButton.coveo-actionbutton:hover,
 .CoveoActionButton.coveo-actionbutton:active {
     & {
-        color: $accent-color;
+        color: $primary-color-dark;
         background-color: $primary-color-lightest-hover;
     }
 
     .coveo-actionbutton_icon svg {
-        fill: $accent-color;
+        fill: $primary-color-dark;
     }
 }

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -1,9 +1,9 @@
 import { Component, ComponentOptions, IResultsComponentBindings, Initialization } from 'coveo-search-ui';
 
 export interface IActionButtonOptions {
+    icon?: string;
     title?: string;
     tooltip?: string;
-    icon?: string;
     click?: () => void;
 }
 
@@ -88,6 +88,19 @@ export class ActionButton extends Component {
 
         if (this.options.click) {
             Coveo.$$(element).on('click', () => this.options.click());
+        }
+    }
+
+    public updateIcon(icon: string): void {
+        const iconElement = this.element.querySelector('.coveo-actionbutton_icon');
+        if (iconElement && icon && icon != iconElement.innerHTML) {
+            iconElement.innerHTML = icon;
+        }
+    }
+
+    public updateTooltip(tooltip: string): void {
+        if (tooltip && tooltip != this.element.title) {
+            this.element.title = tooltip;
         }
     }
 

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -91,6 +91,10 @@ export class ActionButton extends Component {
         }
     }
 
+    /**
+     * Updates the button icon.
+     * @param icon Markup of the SVG icon to set.
+     */
     public updateIcon(icon: string): void {
         const iconElement = this.element.querySelector('.coveo-actionbutton_icon');
         if (iconElement && icon && icon != iconElement.innerHTML) {
@@ -98,6 +102,10 @@ export class ActionButton extends Component {
         }
     }
 
+    /**
+     * Updates the button tooltip.
+     * @param tooltip The tooltip to set.
+     */
     public updateTooltip(tooltip: string): void {
         if (tooltip && tooltip != this.element.title) {
             this.element.title = tooltip;

--- a/src/components/ActionButton/ToggleActionButton.scss
+++ b/src/components/ActionButton/ToggleActionButton.scss
@@ -1,0 +1,15 @@
+@import './ActionButton.scss';
+@import '../../sass/Variables.scss';
+
+$activated-color: $calypso;
+
+button.CoveoActionButton.coveo-actionbutton.coveo-toggleactionbutton-activated {
+    background-color: $activated-color;
+    border-color: $activated-color;
+
+    .coveo-actionbutton_icon {
+        svg {
+            fill: $primary-color-lightest;
+        }
+    }
+}

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -13,6 +13,7 @@ export interface IToggleActionButtonOptions {
 
 export class ToggleActionButton extends Component {
     static ID = 'ToggleActionButton';
+    static ACTIVATED_CLASS_NAME = 'coveo-toggleactionbutton-activated';
 
     static options: IToggleActionButtonOptions = {
         /**
@@ -76,16 +77,35 @@ export class ToggleActionButton extends Component {
          */
         tooltip: ComponentOptions.buildStringOption(),
 
+        /**
+         * Specifies the handler called when the button is clicked.
+         *
+         * Default is `null`.
+         *
+         * This option is set in JavaScript when initializing the component.
+         */
         click: ComponentOptions.buildCustomOption(s => null),
 
+        /**
+         * Specifies the handler called when the button is activated.
+         *
+         * Default is `null`.
+         *
+         * This option is set in JavaScript when initializing the component.
+         */
         activate: ComponentOptions.buildCustomOption(s => null),
 
+        /**
+         * Specifies the handler called when the button is deactivated.
+         *
+         * Default is `null`.
+         *
+         * This option is set in JavaScript when initializing the component.
+         */
         deactivate: ComponentOptions.buildCustomOption(s => null)
     };
 
-    private static ACTIVATED_CLASS_NAME = 'coveo-toggleactionbutton-activated';
-
-    private isActivated: boolean = false;
+    private _isActivated: boolean = false;
     private innerButton: ActionButton;
 
     constructor(public element: HTMLElement, public options: IToggleActionButtonOptions, public bindings?: IResultsComponentBindings) {
@@ -93,6 +113,39 @@ export class ToggleActionButton extends Component {
         this.options = ComponentOptions.initComponentOptions(element, ToggleActionButton, options);
 
         this.createInnerButton(bindings);
+    }
+
+    /**
+     * Indicates whether the toggle button is in the activated state.
+     */
+    public isActivated(): boolean {
+        return this._isActivated;
+    }
+
+    /**
+     * Sets the toggle button to the specified state.
+     * @param activated Whether the button is activated.
+     */
+    public setActivated(activated: boolean): void {
+        if (activated !== this.isActivated()) {
+            this._isActivated = activated;
+            this.updateButton();
+
+            if (this._isActivated && this.options.activate) {
+                this.options.activate();
+            }
+            if (!this._isActivated && this.options.deactivate) {
+                this.options.deactivate();
+            }
+        }
+    }
+
+    protected onClick(): void {
+        this.setActivated(!this.isActivated());
+
+        if (this.options.click) {
+            this.options.click();
+        }
     }
 
     private createInnerButton(bindings?: IResultsComponentBindings): void {
@@ -109,23 +162,8 @@ export class ToggleActionButton extends Component {
         this.updateButton();
     }
 
-    protected onClick(): void {
-        this.isActivated = !this.isActivated;
-        this.updateButton();
-
-        if (this.options.click) {
-            this.options.click();
-        }
-        if (this.isActivated && this.options.activate) {
-            this.options.activate();
-        }
-        if (!this.isActivated && this.options.deactivate) {
-            this.options.deactivate();
-        }
-    }
-
     private updateButton() {
-        if (this.isActivated) {
+        if (this._isActivated) {
             this.element.classList.add(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'true');
 

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -1,0 +1,144 @@
+import { ComponentOptions, IResultsComponentBindings, Component, Initialization } from 'coveo-search-ui';
+import { ActionButton } from './ActionButton';
+
+export interface IToggleActionButtonOptions {
+    activatedIcon: string;
+    activatedTooltip: string;
+    icon: string;
+    tooltip: string;
+    click?: () => void;
+    activate?: () => void;
+    deactivate?: () => void;
+}
+
+export class ToggleActionButton extends Component {
+    static ID = 'ToggleActionButton';
+
+    static options: IToggleActionButtonOptions = {
+        /**
+         * Specifies the button icon when the button is activated.
+         *
+         * Default is the empty string.
+         *
+         * For example, with this SVG markup:
+         *
+         * ```xml
+         * <svg width="1em" height="1em">...</svg>
+         * ```
+         *
+         * The attribute would be set like this:
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-activated-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * ```
+         */
+        activatedIcon: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the button tooltip when the button is activated.
+         *
+         * Default is the empty string.
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-activated-tooltip='My activated button tooltip'></button>
+         * ```
+         */
+        activatedTooltip: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the button SVG icon.
+         * Note: The SVG markup has to be HTML encoded when set using the HTML attributes.
+         *
+         * Default is the empty string.
+         *
+         * For example, with this SVG markup:
+         *
+         * ```xml
+         * <svg width="1em" height="1em">...</svg>
+         * ```
+         *
+         * The attribute would be set like this:
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * ```
+         */
+        icon: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the button tooltip text.
+         *
+         * Default is the empty string.
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-tooltip='My button tooltip'></button>
+         * ```
+         */
+        tooltip: ComponentOptions.buildStringOption(),
+
+        click: ComponentOptions.buildCustomOption(s => null),
+
+        activate: ComponentOptions.buildCustomOption(s => null),
+
+        deactivate: ComponentOptions.buildCustomOption(s => null)
+    };
+
+    private static ACTIVATED_CLASS_NAME = 'coveo-toggleactionbutton-activated';
+
+    private isActivated: boolean = false;
+    private innerButton: ActionButton;
+
+    constructor(public element: HTMLElement, public options: IToggleActionButtonOptions, public bindings?: IResultsComponentBindings) {
+        super(element, ToggleActionButton.ID, bindings);
+        this.options = ComponentOptions.initComponentOptions(element, ToggleActionButton, options);
+
+        this.createInnerButton(bindings);
+    }
+
+    private createInnerButton(bindings?: IResultsComponentBindings): void {
+        this.innerButton = new ActionButton(
+            this.element,
+            {
+                icon: this.options.icon,
+                tooltip: this.options.tooltip,
+                click: () => this.onClick()
+            },
+            bindings
+        );
+
+        this.updateButton();
+    }
+
+    protected onClick(): void {
+        this.isActivated = !this.isActivated;
+        this.updateButton();
+
+        if (this.options.click) {
+            this.options.click();
+        }
+        if (this.isActivated && this.options.activate) {
+            this.options.activate();
+        }
+        if (!this.isActivated && this.options.deactivate) {
+            this.options.deactivate();
+        }
+    }
+
+    private updateButton() {
+        if (this.isActivated) {
+            this.element.classList.add(ToggleActionButton.ACTIVATED_CLASS_NAME);
+            this.element.setAttribute('aria-pressed', 'true');
+
+            this.innerButton.updateIcon(this.options.activatedIcon);
+            this.innerButton.updateTooltip(this.options.activatedTooltip);
+        } else {
+            this.element.classList.remove(ToggleActionButton.ACTIVATED_CLASS_NAME);
+            this.element.setAttribute('aria-pressed', 'false');
+
+            this.innerButton.updateIcon(this.options.icon);
+            this.innerButton.updateTooltip(this.options.tooltip);
+        }
+    }
+}
+
+Initialization.registerAutoCreateComponent(ToggleActionButton);

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -4,8 +4,8 @@ import { ActionButton } from './ActionButton';
 export interface IToggleActionButtonOptions {
     activatedIcon: string;
     activatedTooltip: string;
-    icon: string;
-    tooltip: string;
+    deactivatedIcon: string;
+    deactivatedTooltip: string;
     click?: () => void;
     activate?: () => void;
     deactivate?: () => void;
@@ -47,7 +47,7 @@ export class ToggleActionButton extends Component {
         activatedTooltip: ComponentOptions.buildStringOption(),
 
         /**
-         * Specifies the button SVG icon.
+         * Specifies the button SVG icon when the button is deactivated.
          * Note: The SVG markup has to be HTML encoded when set using the HTML attributes.
          *
          * Default is the empty string.
@@ -61,21 +61,21 @@ export class ToggleActionButton extends Component {
          * The attribute would be set like this:
          *
          * ```html
-         * <button class='CoveoToggleActionButton' data-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * <button class='CoveoToggleActionButton' data-deactivated-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
          * ```
          */
-        icon: ComponentOptions.buildStringOption(),
+        deactivatedIcon: ComponentOptions.buildStringOption(),
 
         /**
-         * Specifies the button tooltip text.
+         * Specifies the button tooltip text when the button is deactivated.
          *
          * Default is the empty string.
          *
          * ```html
-         * <button class='CoveoToggleActionButton' data-tooltip='My button tooltip'></button>
+         * <button class='CoveoToggleActionButton' data-deactivated-tooltip='My button tooltip'></button>
          * ```
          */
-        tooltip: ComponentOptions.buildStringOption(),
+        deactivatedTooltip: ComponentOptions.buildStringOption(),
 
         /**
          * Specifies the handler called when the button is clicked.
@@ -152,8 +152,8 @@ export class ToggleActionButton extends Component {
         this.innerActionButton = new ActionButton(
             this.element,
             {
-                icon: this.options.icon,
-                tooltip: this.options.tooltip,
+                icon: this.options.deactivatedIcon,
+                tooltip: this.options.deactivatedTooltip,
                 click: () => this.onClick()
             },
             bindings
@@ -173,8 +173,8 @@ export class ToggleActionButton extends Component {
             this.element.classList.remove(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'false');
 
-            this.innerActionButton.updateIcon(this.options.icon);
-            this.innerActionButton.updateTooltip(this.options.tooltip);
+            this.innerActionButton.updateIcon(this.options.deactivatedIcon);
+            this.innerActionButton.updateTooltip(this.options.deactivatedTooltip);
         }
     }
 }

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -106,7 +106,7 @@ export class ToggleActionButton extends Component {
     };
 
     private _isActivated: boolean = false;
-    private innerButton: ActionButton;
+    private innerActionButton: ActionButton;
 
     constructor(public element: HTMLElement, public options: IToggleActionButtonOptions, public bindings?: IResultsComponentBindings) {
         super(element, ToggleActionButton.ID, bindings);
@@ -149,7 +149,7 @@ export class ToggleActionButton extends Component {
     }
 
     private createInnerButton(bindings?: IResultsComponentBindings): void {
-        this.innerButton = new ActionButton(
+        this.innerActionButton = new ActionButton(
             this.element,
             {
                 icon: this.options.icon,
@@ -167,14 +167,14 @@ export class ToggleActionButton extends Component {
             this.element.classList.add(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'true');
 
-            this.innerButton.updateIcon(this.options.activatedIcon);
-            this.innerButton.updateTooltip(this.options.activatedTooltip);
+            this.innerActionButton.updateIcon(this.options.activatedIcon);
+            this.innerActionButton.updateTooltip(this.options.activatedTooltip);
         } else {
             this.element.classList.remove(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'false');
 
-            this.innerButton.updateIcon(this.options.icon);
-            this.innerButton.updateTooltip(this.options.tooltip);
+            this.innerActionButton.updateIcon(this.options.icon);
+            this.innerActionButton.updateTooltip(this.options.tooltip);
         }
     }
 }

--- a/src/sass/Index.scss
+++ b/src/sass/Index.scss
@@ -1,4 +1,5 @@
 @import '../components/ActionButton/ActionButton.scss';
+@import '../components/ActionButton/ToggleActionButton.scss';
 @import '../components/AttachResult/AttachResult.scss';
 @import '../components/UserActions/UserActions.scss';
 @import '../components/ViewedByCustomer/ViewedByCustomer.scss';

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -30,6 +30,27 @@ describe('ActionButton', () => {
         sandbox.restore();
     });
 
+    function createActionButton(options: IActionButtonOptions) {
+        const element = document.createElement('button');
+        const componentSetup = Mock.advancedComponentSetup<ActionButton>(ActionButton, new Mock.AdvancedComponentSetupOptions(element, options));
+        return componentSetup.cmp;
+    }
+
+    function setOption(optionName: string, optionValue: any) {
+        const dictOptions = options as { [key: string]: any };
+        dictOptions[optionName] = optionValue;
+    }
+
+    function assertIconsAreEqual(actualIcon: string, expectedIcon: string) {
+        const actualElement = document.createElement('span');
+        actualElement.innerHTML = actualIcon;
+
+        const expectedElement = document.createElement('span');
+        expectedElement.innerHTML = expectedIcon;
+
+        expect(actualElement.innerHTML).toEqual(expectedElement.innerHTML);
+    }
+
     it('should not log warnings in the console', () => {
         expect(consoleWarnSpy.called).toBeFalse();
     });
@@ -93,6 +114,24 @@ describe('ActionButton', () => {
         });
     });
 
+    describe('updateIcon', () => {
+        it('should update the button icon', () => {
+            testSubject.updateIcon(icons.duplicate);
+
+            const iconChild = testSubject.element.querySelector('.coveo-actionbutton_icon');
+            assertIconsAreEqual(iconChild.innerHTML, icons.duplicate);
+        });
+    });
+
+    describe('updateTooltip', () => {
+        it('should update the button tooltip', () => {
+            const newTooltip = 'some new tooltip';
+            testSubject.updateTooltip(newTooltip);
+
+            expect(testSubject.element.title).toEqual(newTooltip);
+        });
+    });
+
     [
         {
             optionName: 'title',
@@ -134,15 +173,4 @@ describe('ActionButton', () => {
             });
         });
     });
-
-    const createActionButton = (options: IActionButtonOptions) => {
-        const element = document.createElement('button');
-        const componentSetup = Mock.advancedComponentSetup<ActionButton>(ActionButton, new Mock.AdvancedComponentSetupOptions(element, options));
-        return componentSetup.cmp;
-    };
-
-    const setOption = (optionName: string, optionValue: any) => {
-        const dictOptions = options as { [key: string]: any };
-        dictOptions[optionName] = optionValue;
-    };
 });

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -1,0 +1,132 @@
+import { SinonSandbox, createSandbox, spy, SinonSpy } from 'sinon';
+import { Mock } from 'coveo-search-ui-tests';
+import { IToggleActionButtonOptions, ToggleActionButton } from '../../../src/components/ActionButton/ToggleActionButton';
+import * as icons from '../../../src/utils/icons';
+import { ActionButton } from '../../../src/components/ActionButton/ActionButton';
+
+describe('ToggleActionButton', () => {
+    let sandbox: SinonSandbox;
+    let options: IToggleActionButtonOptions;
+    let testSubject: ToggleActionButton;
+
+    let clickSpy: SinonSpy;
+    let activateSpy: SinonSpy;
+    let deactivateSpy: SinonSpy;
+    let updateIconSpy: SinonSpy;
+    let updateTooltipSpy: SinonSpy;
+
+    beforeAll(() => {
+        sandbox = createSandbox();
+
+        clickSpy = spy();
+        activateSpy = spy();
+        deactivateSpy = spy();
+        updateIconSpy = spy(<any>ActionButton.prototype, 'updateIcon');
+        updateTooltipSpy = spy(<any>ActionButton.prototype, 'updateTooltip');
+    });
+
+    beforeEach(() => {
+        options = {
+            activatedIcon: icons.duplicate,
+            activatedTooltip: 'activated tooltip',
+            icon: icons.copy,
+            tooltip: 'tooltip',
+            click: clickSpy,
+            activate: activateSpy,
+            deactivate: deactivateSpy
+        };
+
+        testSubject = createToggleButton(options);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    function createToggleButton(options: IToggleActionButtonOptions) {
+        const element = document.createElement('button');
+        const componentSetup = Mock.advancedComponentSetup<ToggleActionButton>(
+            ToggleActionButton,
+            new Mock.AdvancedComponentSetupOptions(element, options)
+        );
+        return componentSetup.cmp;
+    }
+
+    describe('clicking the button', () => {
+        beforeEach(() => {
+            Coveo.$$(testSubject.element).trigger('click');
+        });
+
+        it('should call the click handler', () => {
+            expect(clickSpy.called).toBeTrue();
+        });
+    });
+
+    describe('activating the button', () => {
+        beforeEach(() => {
+            testSubject.setActivated(true);
+        });
+
+        it('should have the isActivated method return true', () => {
+            expect(testSubject.isActivated()).toBeTrue();
+        });
+
+        it('should call the activate handler', () => {
+            expect(activateSpy.called).toBeTrue();
+        });
+
+        it('should add the activated marker CSS class', () => {
+            const hasMarkerClass = testSubject.element.classList.contains(ToggleActionButton.ACTIVATED_CLASS_NAME);
+            expect(hasMarkerClass).toBeTrue();
+        });
+
+        it('should set aria-pressed attribute to true', () => {
+            const attributeValue = testSubject.element.getAttribute('aria-pressed');
+
+            expect(attributeValue).toEqual('true');
+        });
+
+        it('should update button with activated icon', () => {
+            expect(updateIconSpy.calledWith(options.activatedIcon)).toBeTrue();
+        });
+
+        it('should update button with activated tooltip', () => {
+            expect(updateTooltipSpy.calledWith(options.activatedTooltip)).toBeTrue();
+        });
+    });
+
+    describe('deactivating the button', () => {
+        beforeEach(() => {
+            testSubject.setActivated(true);
+            [clickSpy, activateSpy, deactivateSpy, updateIconSpy, updateTooltipSpy].forEach(s => s.resetHistory());
+
+            testSubject.setActivated(false);
+        });
+
+        it('should have the isActivated method return false', () => {
+            expect(testSubject.isActivated()).toBeFalse();
+        });
+
+        it('should call the deactivate handler', () => {
+            expect(deactivateSpy.called).toBeTrue();
+        });
+
+        it('should remove the activated marker CSS class', () => {
+            const hasMarkerClass = testSubject.element.classList.contains(ToggleActionButton.ACTIVATED_CLASS_NAME);
+            expect(hasMarkerClass).toBeFalse();
+        });
+
+        it('should set aria-pressed attribute to false', () => {
+            const attributeValue = testSubject.element.getAttribute('aria-pressed');
+            expect(attributeValue).toEqual('false');
+        });
+
+        it('should update button with icon', () => {
+            expect(updateIconSpy.calledWith(options.icon)).toBeTrue();
+        });
+
+        it('should update button with tooltip', () => {
+            expect(updateTooltipSpy.calledWith(options.tooltip)).toBeTrue();
+        });
+    });
+});

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -1,4 +1,4 @@
-import { SinonSandbox, createSandbox, spy, SinonSpy } from 'sinon';
+import { SinonSandbox, createSandbox, SinonSpy } from 'sinon';
 import { Mock } from 'coveo-search-ui-tests';
 import { IToggleActionButtonOptions, ToggleActionButton } from '../../../src/components/ActionButton/ToggleActionButton';
 import * as icons from '../../../src/utils/icons';
@@ -18,11 +18,11 @@ describe('ToggleActionButton', () => {
     beforeAll(() => {
         sandbox = createSandbox();
 
-        clickSpy = spy();
-        activateSpy = spy();
-        deactivateSpy = spy();
-        updateIconSpy = spy(<any>ActionButton.prototype, 'updateIcon');
-        updateTooltipSpy = spy(<any>ActionButton.prototype, 'updateTooltip');
+        clickSpy = sandbox.spy();
+        activateSpy = sandbox.spy();
+        deactivateSpy = sandbox.spy();
+        updateIconSpy = sandbox.spy(<any>ActionButton.prototype, 'updateIcon');
+        updateTooltipSpy = sandbox.spy(<any>ActionButton.prototype, 'updateTooltip');
     });
 
     beforeEach(() => {
@@ -40,7 +40,7 @@ describe('ToggleActionButton', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sandbox.reset();
     });
 
     function createToggleButton(options: IToggleActionButtonOptions) {
@@ -98,7 +98,7 @@ describe('ToggleActionButton', () => {
     describe('deactivating the button', () => {
         beforeEach(() => {
             testSubject.setActivated(true);
-            [clickSpy, activateSpy, deactivateSpy, updateIconSpy, updateTooltipSpy].forEach(s => s.resetHistory());
+            sandbox.reset();
 
             testSubject.setActivated(false);
         });

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -29,8 +29,8 @@ describe('ToggleActionButton', () => {
         options = {
             activatedIcon: icons.duplicate,
             activatedTooltip: 'activated tooltip',
-            icon: icons.copy,
-            tooltip: 'tooltip',
+            deactivatedIcon: icons.copy,
+            deactivatedTooltip: 'tooltip',
             click: clickSpy,
             activate: activateSpy,
             deactivate: deactivateSpy
@@ -121,12 +121,12 @@ describe('ToggleActionButton', () => {
             expect(attributeValue).toEqual('false');
         });
 
-        it('should update button with icon', () => {
-            expect(updateIconSpy.calledWith(options.icon)).toBeTrue();
+        it('should update button with deactivated icon', () => {
+            expect(updateIconSpy.calledWith(options.deactivatedIcon)).toBeTrue();
         });
 
-        it('should update button with tooltip', () => {
-            expect(updateTooltipSpy.calledWith(options.tooltip)).toBeTrue();
+        it('should update button with deactivated tooltip', () => {
+            expect(updateTooltipSpy.calledWith(options.deactivatedTooltip)).toBeTrue();
         });
     });
 });


### PR DESCRIPTION
This PR adds the _ToggleActionButton_ component. As its name states, it simply is an _ActionButton_ featuring a toggle state. In addition, to keep things simple, this button supports only having an icon and tooltip. A different icon and tooltip can be displayed when the button is activated.

Using the options, the caller might attach handlers when the button is either clicked, activated, or deactivated.