### PR TITLE
Added case and article ids to AttachResult custom events

### DIFF
--- a/pages/attached_result.html
+++ b/pages/attached_result.html
@@ -79,7 +79,7 @@
                     <div class="coveo-result-frame">
                       <div class="CoveoResultActionsMenu">
                         <div class="CoveoQuickview"></div>
-                        <div class="CoveoAttachResult" data-attach-caption="Attach" data-detach-caption="Detach"></div>
+                        <div class="CoveoAttachResult" data-attach-caption="Attach" data-detach-caption="Detach" data-case-id="f00b4r"></div>
                       </div>
                       <div class="coveo-result-cell" style="vertical-align:top;text-align:center;width:32px;">
                         <span class="CoveoIcon" data-small="true" data-with-label="false"></span>

--- a/src/components/AttachResult/AttachResult.ts
+++ b/src/components/AttachResult/AttachResult.ts
@@ -203,14 +203,11 @@ export class AttachResult extends Component {
         let customData: IAnalyticsCaseAttachMeta = {
             resultUriHash: this.queryResult.raw.urihash,
             author: this.queryResult.raw.author,
-            articleID:
-                this.options.articleIdField && this.queryResult.raw[this.options.articleIdField]
-                    ? this.queryResult.raw[this.options.articleIdField]
-                    : null,
+            articleID: this.queryResult.raw[this.options.articleIdField],
             caseID: this.options.caseId
         };
 
-        this.usageAnalytics.logCustomEvent<IAnalyticsCaseDetachMeta>(cause, customData, this.root);
+        this.usageAnalytics.logCustomEvent<IAnalyticsCaseDetachMeta>(cause, customData, this.element, this.queryResult);
     }
 
     protected render(): void {


### PR DESCRIPTION
Small addition to the AttachResult component to specify the caseId and the field where the articleId can be obtained. For ServiceNow, the articleId is pretty much always the permanentID and the caseID is static on the page. Tested using the local test page.

- Added case and article ids to AttachResult custom events
- Added click event when attaching in AttachResult

SNOW-364