### PR TITLE
feat(SFINT-3300): Improve ToggleActionButton option names

### DIFF
--- a/pages/toggle_action_button.html
+++ b/pages/toggle_action_button.html
@@ -37,5 +37,17 @@
                 data-deactivate-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
             ></button>
         </div>
+
+        <div>
+            <h2>Toggle Button (legacy options)</h2>
+            <br />
+            <button
+                class="CoveoToggleActionButton"
+                data-deactivated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
+                data-deactivated-tooltip="Activate feature"
+                data-activated-tooltip="Deactivate feature"
+                data-activated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
+            ></button>
+        </div>
     </body>
 </html>

--- a/pages/toggle_action_button.html
+++ b/pages/toggle_action_button.html
@@ -31,10 +31,10 @@
             <br />
             <button
                 class="CoveoToggleActionButton"
-                data-deactivated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
-                data-deactivated-tooltip="Normal tooltip"
-                data-activated-tooltip="Activated tooltip"
-                data-activated-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
+                data-activate-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;circle r="39.499" cy="120.385" cx="84.1" transform="translate(-44.601 -80.887)"/&gt;&lt;/svg&gt;'
+                data-activate-tooltip="Activate feature"
+                data-deactivate-tooltip="Deactivate feature"
+                data-deactivate-icon='&lt;svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.997 78.997" height="298.571" width="298.571"&gt;&lt;path d="M39.434 0A39.499 39.499 0 000 39.498a39.499 39.499 0 0039.498 39.5 39.499 39.499 0 0039.5-39.5A39.499 39.499 0 0039.497 0a39.499 39.499 0 00-.064 0zm.59 7.273a31.948 31.948 0 0131.948 31.949A31.948 31.948 0 0140.023 71.17 31.948 31.948 0 018.075 39.222 31.948 31.948 0 0140.023 7.273z"/&gt;&lt;/svg&gt;'
             ></button>
         </div>
     </body>

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -2,10 +2,10 @@ import { ComponentOptions, IResultsComponentBindings, Component, Initialization 
 import { ActionButton } from './ActionButton';
 
 export interface IToggleActionButtonOptions {
-    activatedIcon: string;
-    activatedTooltip: string;
-    deactivatedIcon: string;
-    deactivatedTooltip: string;
+    activateIcon: string;
+    activateTooltip: string;
+    deactivateIcon: string;
+    deactivateTooltip: string;
     click?: () => void;
     activate?: () => void;
     deactivate?: () => void;
@@ -17,37 +17,7 @@ export class ToggleActionButton extends Component {
 
     static options: IToggleActionButtonOptions = {
         /**
-         * Specifies the button icon when the button is activated.
-         *
-         * Default is the empty string.
-         *
-         * For example, with this SVG markup:
-         *
-         * ```xml
-         * <svg width="1em" height="1em">...</svg>
-         * ```
-         *
-         * The attribute would be set like this:
-         *
-         * ```html
-         * <button class='CoveoToggleActionButton' data-activated-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
-         * ```
-         */
-        activatedIcon: ComponentOptions.buildStringOption(),
-
-        /**
-         * Specifies the button tooltip when the button is activated.
-         *
-         * Default is the empty string.
-         *
-         * ```html
-         * <button class='CoveoToggleActionButton' data-activated-tooltip='My activated button tooltip'></button>
-         * ```
-         */
-        activatedTooltip: ComponentOptions.buildStringOption(),
-
-        /**
-         * Specifies the button SVG icon when the button is deactivated.
+         * Specifies the button SVG icon displayed to activate the button.
          * Note: The SVG markup has to be HTML encoded when set using the HTML attributes.
          *
          * Default is the empty string.
@@ -61,21 +31,51 @@ export class ToggleActionButton extends Component {
          * The attribute would be set like this:
          *
          * ```html
-         * <button class='CoveoToggleActionButton' data-deactivated-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * <button class='CoveoToggleActionButton' data-activate-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
          * ```
          */
-        deactivatedIcon: ComponentOptions.buildStringOption(),
+        activateIcon: ComponentOptions.buildStringOption(),
 
         /**
-         * Specifies the button tooltip text when the button is deactivated.
+         * Specifies the button tooltip text displayed to activate the button.
          *
          * Default is the empty string.
          *
          * ```html
-         * <button class='CoveoToggleActionButton' data-deactivated-tooltip='My button tooltip'></button>
+         * <button class='CoveoToggleActionButton' data-activate-tooltip='Activate the feature'></button>
          * ```
          */
-        deactivatedTooltip: ComponentOptions.buildStringOption(),
+        activateTooltip: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the button icon displayed to deactivate the button.
+         *
+         * Default is the empty string.
+         *
+         * For example, with this SVG markup:
+         *
+         * ```xml
+         * <svg width="1em" height="1em">...</svg>
+         * ```
+         *
+         * The attribute would be set like this:
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-deactivate-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
+         * ```
+         */
+        deactivateIcon: ComponentOptions.buildStringOption(),
+
+        /**
+         * Specifies the button tooltip displayed to deactivate the button.
+         *
+         * Default is the empty string.
+         *
+         * ```html
+         * <button class='CoveoToggleActionButton' data-deactivate-tooltip='Deactivate the feature'></button>
+         * ```
+         */
+        deactivateTooltip: ComponentOptions.buildStringOption(),
 
         /**
          * Specifies the handler called when the button is clicked.
@@ -152,8 +152,8 @@ export class ToggleActionButton extends Component {
         this.innerActionButton = new ActionButton(
             this.element,
             {
-                icon: this.options.deactivatedIcon,
-                tooltip: this.options.deactivatedTooltip,
+                icon: this.options.activateIcon,
+                tooltip: this.options.activateTooltip,
                 click: () => this.onClick()
             },
             bindings
@@ -167,14 +167,14 @@ export class ToggleActionButton extends Component {
             this.element.classList.add(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'true');
 
-            this.innerActionButton.updateIcon(this.options.activatedIcon);
-            this.innerActionButton.updateTooltip(this.options.activatedTooltip);
+            this.innerActionButton.updateIcon(this.options.deactivateIcon);
+            this.innerActionButton.updateTooltip(this.options.deactivateTooltip);
         } else {
             this.element.classList.remove(ToggleActionButton.ACTIVATED_CLASS_NAME);
             this.element.setAttribute('aria-pressed', 'false');
 
-            this.innerActionButton.updateIcon(this.options.deactivatedIcon);
-            this.innerActionButton.updateTooltip(this.options.deactivatedTooltip);
+            this.innerActionButton.updateIcon(this.options.activateIcon);
+            this.innerActionButton.updateTooltip(this.options.activateTooltip);
         }
     }
 }

--- a/src/components/ActionButton/ToggleActionButton.ts
+++ b/src/components/ActionButton/ToggleActionButton.ts
@@ -34,7 +34,7 @@ export class ToggleActionButton extends Component {
          * <button class='CoveoToggleActionButton' data-activate-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
          * ```
          */
-        activateIcon: ComponentOptions.buildStringOption(),
+        activateIcon: ComponentOptions.buildStringOption({ alias: 'deactivatedIcon' }),
 
         /**
          * Specifies the button tooltip text displayed to activate the button.
@@ -45,7 +45,7 @@ export class ToggleActionButton extends Component {
          * <button class='CoveoToggleActionButton' data-activate-tooltip='Activate the feature'></button>
          * ```
          */
-        activateTooltip: ComponentOptions.buildStringOption(),
+        activateTooltip: ComponentOptions.buildStringOption({ alias: 'deactivatedTooltip' }),
 
         /**
          * Specifies the button icon displayed to deactivate the button.
@@ -64,7 +64,7 @@ export class ToggleActionButton extends Component {
          * <button class='CoveoToggleActionButton' data-deactivate-icon='&lt;svg width=&quot;1em&quot; height=&quot;1em&quot;&gt;...&lt;/svg&gt;'></button>
          * ```
          */
-        deactivateIcon: ComponentOptions.buildStringOption(),
+        deactivateIcon: ComponentOptions.buildStringOption({ alias: 'activatedIcon' }),
 
         /**
          * Specifies the button tooltip displayed to deactivate the button.
@@ -75,7 +75,7 @@ export class ToggleActionButton extends Component {
          * <button class='CoveoToggleActionButton' data-deactivate-tooltip='Deactivate the feature'></button>
          * ```
          */
-        deactivateTooltip: ComponentOptions.buildStringOption(),
+        deactivateTooltip: ComponentOptions.buildStringOption({ alias: 'activatedTooltip' }),
 
         /**
          * Specifies the handler called when the button is clicked.

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -3,6 +3,7 @@ import { Mock } from 'coveo-search-ui-tests';
 import { IToggleActionButtonOptions, ToggleActionButton } from '../../../src/components/ActionButton/ToggleActionButton';
 import * as icons from '../../../src/utils/icons';
 import { ActionButton } from '../../../src/components/ActionButton/ActionButton';
+import { IComponentOptions } from 'coveo-search-ui';
 
 describe('ToggleActionButton', () => {
     let sandbox: SinonSandbox;
@@ -50,6 +51,11 @@ describe('ToggleActionButton', () => {
             new Mock.AdvancedComponentSetupOptions(element, options)
         );
         return componentSetup.cmp;
+    }
+
+    function getOption(optionName: string): IComponentOptions<any> {
+        const dictOptions = ToggleActionButton.options as { [key: string]: any };
+        return dictOptions[optionName] as IComponentOptions<any>;
     }
 
     describe('clicking the button', () => {
@@ -127,6 +133,21 @@ describe('ToggleActionButton', () => {
 
         it('should update button with activate tooltip', () => {
             expect(updateTooltipSpy.calledWith(options.activateTooltip)).toBeTrue();
+        });
+    });
+
+    describe('legacy options compatibility', () => {
+        [
+            { legacy: 'activatedIcon', current: 'deactivateIcon' },
+            { legacy: 'activatedTooltip', current: 'deactivateTooltip' },
+            { legacy: 'deactivatedIcon', current: 'activateIcon' },
+            { legacy: 'deactivatedTooltip', current: 'activateTooltip' }
+        ].forEach(({ legacy, current }) => {
+            it(`should support legacy '${legacy}' option through '${current}'`, () => {
+                const option = getOption(current);
+
+                expect(option.alias).toContain(legacy);
+            });
         });
     });
 });

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -27,10 +27,10 @@ describe('ToggleActionButton', () => {
 
     beforeEach(() => {
         options = {
-            activatedIcon: icons.duplicate,
-            activatedTooltip: 'activated tooltip',
-            deactivatedIcon: icons.copy,
-            deactivatedTooltip: 'tooltip',
+            activateIcon: icons.copy,
+            activateTooltip: 'Activate feature',
+            deactivateIcon: icons.duplicate,
+            deactivateTooltip: 'Deactivate feature',
             click: clickSpy,
             activate: activateSpy,
             deactivate: deactivateSpy
@@ -86,12 +86,12 @@ describe('ToggleActionButton', () => {
             expect(attributeValue).toEqual('true');
         });
 
-        it('should update button with activated icon', () => {
-            expect(updateIconSpy.calledWith(options.activatedIcon)).toBeTrue();
+        it('should update button with deactivate icon', () => {
+            expect(updateIconSpy.calledWith(options.deactivateIcon)).toBeTrue();
         });
 
-        it('should update button with activated tooltip', () => {
-            expect(updateTooltipSpy.calledWith(options.activatedTooltip)).toBeTrue();
+        it('should update button with deactivate tooltip', () => {
+            expect(updateTooltipSpy.calledWith(options.deactivateTooltip)).toBeTrue();
         });
     });
 
@@ -121,12 +121,12 @@ describe('ToggleActionButton', () => {
             expect(attributeValue).toEqual('false');
         });
 
-        it('should update button with deactivated icon', () => {
-            expect(updateIconSpy.calledWith(options.deactivatedIcon)).toBeTrue();
+        it('should update button with activate icon', () => {
+            expect(updateIconSpy.calledWith(options.activateIcon)).toBeTrue();
         });
 
-        it('should update button with deactivated tooltip', () => {
-            expect(updateTooltipSpy.calledWith(options.deactivatedTooltip)).toBeTrue();
+        it('should update button with activate tooltip', () => {
+            expect(updateTooltipSpy.calledWith(options.activateTooltip)).toBeTrue();
         });
     });
 });


### PR DESCRIPTION
Some of the _ToggleActionButton_ options were confusing because their value was kind of the inverse of the option name. For example, the `activatedTooltip` option could have a value like `Deactivate feature xyz`.

These options were renamed like this:

    activatedTooltip   --> deactivateTooltip
    activatedIcon      --> deactivateIcon
    deactivatedTooltip --> activateTooltip
    deactivatedIcon    --> activateIcon

This way the option values would read like this:

    activateTooltip: 'Activate feature xyz'
    deactivateTooltip: 'Deactivate feature xyz'
