### PR TITLE
fixeat(SFINT-3295): Improve UserActions interactivity

### DIFF
--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -70,6 +70,13 @@ export interface IUserActionsOptions {
      * Default: `False`
      */
     hidden: Boolean;
+    /**
+     * Whether or not the UserAction component should use the CoveoSearchUI ResponsiveManager
+     * Inoperant if `hidden` is true.
+     *
+     * Default: `True`
+     */
+    useResponsiveManager: Boolean;
 }
 
 /**
@@ -100,6 +107,9 @@ export class UserActions extends Component {
         }),
         hidden: ComponentOptions.buildBooleanOption({
             defaultValue: false
+        }),
+        useResponsiveManager: ComponentOptions.buildBooleanOption({
+            defaultValue: true
         })
     };
 
@@ -130,7 +140,9 @@ export class UserActions extends Component {
         this.tagViewsOfUser();
 
         if (!options.hidden) {
-            ResponsiveUserActions.init(this.root, this);
+            if (options.useResponsiveManager) {
+                ResponsiveUserActions.init(this.root, this);
+            }
             this.bind.onRootElement(QueryEvents.newQuery, () => this.hide());
             this.hide();
         }

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -87,6 +87,10 @@ export class UserActions extends Component {
      * Identifier of the Search-UI component.
      */
     static readonly ID = 'UserActions';
+    static readonly Events = {
+        Hide: 'userActionsPanelHide',
+        Show: 'userActionsPanelShow'
+    };
 
     /**
      * Default initialization options of the **UserActions** class.
@@ -156,33 +160,45 @@ export class UserActions extends Component {
             (get(this.root, UserProfileModel) as UserProfileModel).deleteActions(this.options.userId);
             this.root.classList.remove(UserActions.USER_ACTION_OPENED);
             this.isOpened = false;
+            this.element.dispatchEvent(new CustomEvent(UserActions.Events.Hide));
         }
     }
 
     /**
      * Open the panel.
      */
-    public show() {
+    public async show() {
         if (!this.isOpened) {
-            (get(this.root, UserProfileModel) as UserProfileModel)
-                .getActions(this.options.userId)
-                .then(actions => (actions.length > 0 ? this.render() : this.renderNoActions()))
-                .catch(e => (e && e.statusCode === 404 ? this.renderEnablePrompt() : this.renderNoActions()));
-
+            this.element.dispatchEvent(new CustomEvent(UserActions.Events.Show));
             this.bindings.usageAnalytics.logCustomEvent({ name: 'openUserActions', type: 'User Actions' }, {}, this.element);
             this.root.classList.add(UserActions.USER_ACTION_OPENED);
             this.isOpened = true;
+
+            try {
+                const userActions = await (get(this.root, UserProfileModel) as UserProfileModel).getActions(this.options.userId);
+                if (userActions.length > 0) {
+                    this.render();
+                } else {
+                    this.renderNoActions();
+                }
+            } catch (e) {
+                if (e && e.statusCode === 404) {
+                    this.renderEnablePrompt();
+                } else {
+                    this.renderNoActions();
+                }
+            }
         }
     }
 
     /**
      * Toggle the visibility of the panel.
      */
-    public toggle() {
+    public async toggle() {
         if (this.isOpened) {
             this.hide();
         } else {
-            this.show();
+            await this.show();
         }
     }
 

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -182,7 +182,7 @@ export class UserActions extends Component {
                     this.renderNoActions();
                 }
             } catch (e) {
-                if (e && e.statusCode === 404) {
+                if (e?.statusCode === 404) {
                     this.renderEnablePrompt();
                 } else {
                     this.renderNoActions();

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -486,6 +486,13 @@ describe('UserActions', () => {
                 expect(modelMock.getActions.calledWithExactly(someUserId)).toBe(true);
             });
         });
+
+        it('should trigger a userActionsShow event', () => {
+            const spyDispatchEvent = sandbox.spy(mock.cmp.element, 'dispatchEvent');
+            mock.cmp.show();
+
+            expect(spyDispatchEvent.calledOnceWith(new CustomEvent('userActionsPanelHide')));
+        });
     });
 
     describe('hide', () => {
@@ -543,6 +550,15 @@ describe('UserActions', () => {
             return delay(() => {
                 expect(modelMock.deleteActions.calledWithExactly(someUserId)).toBe(true);
             });
+        });
+
+        it('should trigger a userActionsHide event', () => {
+            mock.cmp.show();
+            const spyDispatchEvent = sandbox.spy(mock.cmp.element, 'dispatchEvent');
+
+            mock.cmp.hide();
+
+            expect(spyDispatchEvent.calledOnceWith(new CustomEvent('userActionsPanelHide')));
         });
     });
 

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -76,10 +76,44 @@ describe('UserActions', () => {
 
     it('should not be displayed if hidden option is true', () => {
         const responsiveComponentStub = sandbox.stub(ResponsiveUserActions, 'init');
+        const hideSpy = sandbox.spy(UserActions.prototype, 'hide');
 
         Mock.advancedComponentSetup<UserActions>(
             UserActions,
             new Mock.AdvancedComponentSetupOptions(null, { userId: 'testuserId', hidden: true }, env => {
+                fakeUserProfileModel(env.root, sandbox).getActions.returns(Promise.resolve(ACTIONS));
+                return env;
+            })
+        );
+
+        return delay(() => {
+            expect(hideSpy.called).toBe(false);
+            expect(responsiveComponentStub.called).toBe(false);
+        });
+    });
+
+    it('should register to the ResponsiveComponentManager by default', () => {
+        const responsiveComponentStub = sandbox.stub(ResponsiveUserActions, 'init');
+
+        Mock.advancedComponentSetup<UserActions>(
+            UserActions,
+            new Mock.AdvancedComponentSetupOptions(null, { userId: 'testuserId' }, env => {
+                fakeUserProfileModel(env.root, sandbox).getActions.returns(Promise.resolve(ACTIONS));
+                return env;
+            })
+        );
+
+        return delay(() => {
+            expect(responsiveComponentStub.called).toBe(true);
+        });
+    });
+
+    it('should not register to the ResponsiveComponentManager when useResponsiveManager is false', () => {
+        const responsiveComponentStub = sandbox.stub(ResponsiveUserActions, 'init');
+
+        Mock.advancedComponentSetup<UserActions>(
+            UserActions,
+            new Mock.AdvancedComponentSetupOptions(null, { userId: 'testuserId', useResponsiveManager: false }, env => {
                 fakeUserProfileModel(env.root, sandbox).getActions.returns(Promise.resolve(ACTIONS));
                 return env;
             })


### PR DESCRIPTION
# Changes
## Add useResponsiveManager option
Add a useResponsiveManager option, default to true. Previous behaviour is kept, meaning that if you have hidden, the useResponsiveManager will be inoperant because hidden does super-seed it.

It allows SFINT to use the UserActions without hooking it to the ResponsiveComponentManager, will preserving its other functionality.

## Add events for show and hide of the UserActions panel
Allow other components to be notified of when the UserActions panel is shown or hidden.

It allows SFINT to sync up the state of the ToggleActionButton with the panel when the latter get closed by something else than the button (e.g. query)


# Tests
- UT
- SAN checked in SFINT