### PR TITLE
feat(SFINT-3327): Add disable support for ActionButtons

### DIFF
--- a/pages/action_button.html
+++ b/pages/action_button.html
@@ -61,5 +61,33 @@
                 <button class="CoveoActionButton" data-title="Third"></button>
             </div>
         </div>
+
+        <div id="disabled-section">
+            <h2>Disabled buttons</h2>
+
+            <br />
+
+            <div style="display: flex;">
+                <button
+                    class="CoveoActionButton"
+                    data-icon='&lt;svg width=".5em" height=".5em" viewBox="0 0 20 20"&gt;&lt;path d="M4 5h7v1H4V5m0 3h7v1H4V8m0 3h7v1H4v-1"&gt;&lt;/path&gt;&lt;path d="M15 1c.009-.525.066-1-1-1H1.002c-.651 0-1 .33-1 1v15c0 .66.351 1 1 1H3v2c.075.546.383 1 1 1h13c.718 0 1-.295 1-1V3c.001-.468-.406-.99-1-1h-2V1M2 15V2h11v13H2m14 3H5v-.995L14 17c.5.005.976-.428 1-1l.021-12H16v14"&gt;&lt;/path&gt;&lt;/svg&gt;'
+                ></button>
+                <button
+                    class="CoveoActionButton"
+                    data-title="The Text"
+                    data-icon='&lt;svg width=".5em" height=".5em" viewBox="0 0 20 20"&gt;&lt;path d="M4 5h7v1H4V5m0 3h7v1H4V8m0 3h7v1H4v-1"&gt;&lt;/path&gt;&lt;path d="M15 1c.009-.525.066-1-1-1H1.002c-.651 0-1 .33-1 1v15c0 .66.351 1 1 1H3v2c.075.546.383 1 1 1h13c.718 0 1-.295 1-1V3c.001-.468-.406-.99-1-1h-2V1M2 15V2h11v13H2m14 3H5v-.995L14 17c.5.005.976-.428 1-1l.021-12H16v14"&gt;&lt;/path&gt;&lt;/svg&gt;'
+                ></button>
+                <button class="CoveoActionButton" data-title="The Text"></button>
+            </div>
+            <!-- Disable buttons in the section through JavaScript to ensure disabled=true -->
+            <script>
+                Coveo.$$(document.getElementById('search')).one('afterInitialization', () => {
+                    var buttons = document.getElementById('disabled-section').querySelectorAll('.CoveoActionButton');
+                    for (var i = 0; i < buttons.length; i++) {
+                        Coveo.get(buttons[i], 'ActionButton').disable();
+                    }
+                });
+            </script>
+        </div>
     </body>
 </html>

--- a/src/components/ActionButton/ActionButton.scss
+++ b/src/components/ActionButton/ActionButton.scss
@@ -15,6 +15,17 @@ button.CoveoActionButton.coveo-actionbutton {
     align-items: center;
     justify-content: center;
     white-space: nowrap;
+
+    &.coveo-disabled {
+        color: $primary-color-light;
+
+        .coveo-actionbutton_icon svg {
+            fill: $primary-color-light;
+        }
+        &:hover {
+            background-color: $primary-color-lightest;
+        }
+    }
 }
 
 .CoveoActionButton {

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -15,6 +15,8 @@ export interface IActionButtonOptions {
  * ```
  */
 export class ActionButton extends Component {
+    private static readonly CoveoDisabledClass = 'coveo-disabled';
+
     static ID = 'ActionButton';
 
     /**
@@ -87,8 +89,28 @@ export class ActionButton extends Component {
         }
 
         if (this.options.click) {
-            Coveo.$$(element).on('click', () => this.options.click());
+            Coveo.$$(element).on('click', () => {
+                if (!this.disabled) {
+                    this.options.click();
+                }
+            });
         }
+    }
+
+    /**
+     * Disable the button.
+     */
+    public disable() {
+        super.disable();
+        this.element.classList.add(ActionButton.CoveoDisabledClass);
+    }
+
+    /**
+     * Enable the button.
+     */
+    public enable() {
+        super.enable();
+        this.element.classList.remove(ActionButton.CoveoDisabledClass);
     }
 
     /**

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -103,6 +103,7 @@ export class ActionButton extends Component {
     public disable() {
         super.disable();
         this.element.classList.add(ActionButton.CoveoDisabledClass);
+        this.element.setAttribute('disabled', '');
     }
 
     /**
@@ -111,6 +112,7 @@ export class ActionButton extends Component {
     public enable() {
         super.enable();
         this.element.classList.remove(ActionButton.CoveoDisabledClass);
+        this.element.removeAttribute('disabled');
     }
 
     /**

--- a/src/components/ActionButton/ActionButton.ts
+++ b/src/components/ActionButton/ActionButton.ts
@@ -15,8 +15,6 @@ export interface IActionButtonOptions {
  * ```
  */
 export class ActionButton extends Component {
-    private static readonly CoveoDisabledClass = 'coveo-disabled';
-
     static ID = 'ActionButton';
 
     /**
@@ -90,29 +88,9 @@ export class ActionButton extends Component {
 
         if (this.options.click) {
             Coveo.$$(element).on('click', () => {
-                if (!this.disabled) {
-                    this.options.click();
-                }
+                this.options.click();
             });
         }
-    }
-
-    /**
-     * Disable the button.
-     */
-    public disable() {
-        super.disable();
-        this.element.classList.add(ActionButton.CoveoDisabledClass);
-        this.element.setAttribute('disabled', '');
-    }
-
-    /**
-     * Enable the button.
-     */
-    public enable() {
-        super.enable();
-        this.element.classList.remove(ActionButton.CoveoDisabledClass);
-        this.element.removeAttribute('disabled');
     }
 
     /**

--- a/src/components/ActionButton/StatefulActionButton.ts
+++ b/src/components/ActionButton/StatefulActionButton.ts
@@ -1,0 +1,72 @@
+import { IResultsComponentBindings } from 'coveo-search-ui';
+import { ActionButton, IActionButtonOptions } from './ActionButton';
+
+export interface IStatefulActionButtonState extends IActionButtonOptions {
+    onStateEntry?: (this: StatefulActionButton) => void;
+    onStateExit?: (this: StatefulActionButton) => void;
+}
+
+export interface IStatefulActionButtonTransition {
+    from: IStatefulActionButtonState;
+    to: IStatefulActionButtonState;
+}
+
+export interface IStatefulActionButtonOptions {
+    states: IStatefulActionButtonState[];
+    allowedTransitions?: IStatefulActionButtonTransition[];
+    initalState: IStatefulActionButtonState;
+}
+
+export class StatefulActionButton {
+    static ID = 'StatefulActionButton';
+    private currentState: IStatefulActionButtonState;
+    private innerActionButton: ActionButton;
+
+    constructor(public element: HTMLElement, public options: IStatefulActionButtonOptions, public bindings?: IResultsComponentBindings) {
+        if (!this.areOptionsValid()) {
+            return;
+        }
+        this.currentState = this.options.initalState;
+        this.innerActionButton = new ActionButton(element, { ...this.options.initalState, click: this.handleClick.bind(this) }, bindings);
+    }
+
+    private handleClick() {
+        this.currentState.click();
+    }
+
+    public switchTo(state: IStatefulActionButtonState) {
+        if (!this.isTransitionAllowed(state)) {
+            return;
+        }
+        this.currentState.onStateExit?.apply(this);
+        state.onStateEntry?.apply(this);
+        this.innerActionButton.updateIcon(state.icon);
+        this.innerActionButton.updateTooltip(state.tooltip);
+        this.currentState = state;
+    }
+
+    public getCurrentState() {
+        return this.currentState;
+    }
+
+    private isTransitionAllowed(state: IStatefulActionButtonState) {
+        return (
+            !this.options.allowedTransitions ||
+            this.options.allowedTransitions.some((transition) => transition.from === this.currentState && transition.to === state)
+        );
+    }
+
+    private areOptionsValid() {
+        if (!this.options.states?.length) {
+            console.warn('The stateful action button cannot render if no states are defined.');
+            Coveo.$$(this.element).hide();
+            return false;
+        }
+        if (this.options.states.indexOf(this.options.initalState) < 0) {
+            console.warn('The stateful action button cannot render if the initial state is not in the list of states.');
+            Coveo.$$(this.element).hide();
+            return false;
+        }
+        return true;
+    }
+}

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -4,6 +4,8 @@ import { ActionButton, IActionButtonOptions } from '../../../src/components/Acti
 import * as icons from '../../../src/utils/icons';
 
 describe('ActionButton', () => {
+    const CoveoDisabledClass = 'coveo-disabled';
+
     let sandbox: SinonSandbox;
     let options: IActionButtonOptions;
     let testSubject: ActionButton;
@@ -64,10 +66,28 @@ describe('ActionButton', () => {
             testSubject = createActionButton(options);
         });
 
-        it('should call the handler when clicking the button', () => {
-            testSubject.element.dispatchEvent(new Event('click', {}));
+        describe('if disabled', () => {
+            beforeEach(() => {
+                testSubject.disabled = true;
+            });
 
-            expect(clickHandlerSpy.called).toBeTrue();
+            it('should not call the handler when clicking the button', () => {
+                testSubject.element.dispatchEvent(new Event('click', {}));
+
+                expect(clickHandlerSpy.called).toBeFalse();
+            });
+        });
+
+        describe('if enabled', () => {
+            beforeEach(() => {
+                testSubject.disabled = false;
+            });
+
+            it('should call the handler when clicking the button', () => {
+                testSubject.element.dispatchEvent(new Event('click', {}));
+
+                expect(clickHandlerSpy.called).toBeTrue();
+            });
         });
     });
 
@@ -171,6 +191,30 @@ describe('ActionButton', () => {
                 const actual = testSubject.element.querySelector(testCase.expectedSelector);
                 expect(actual).toBeDefined();
             });
+        });
+    });
+
+    describe('disable', () => {
+        it(`should add the CSS class ${CoveoDisabledClass} and set the property disabled to true`, () => {
+            testSubject.disabled = false;
+            testSubject.element.classList.remove(CoveoDisabledClass);
+
+            testSubject.disable();
+
+            expect(testSubject.disabled).toBeTrue();
+            expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeTrue();
+        });
+    });
+
+    describe('enable', () => {
+        it(`should add the CSS class ${CoveoDisabledClass} and set the property disabled to true`, () => {
+            testSubject.disabled = true;
+            testSubject.element.classList.add(CoveoDisabledClass);
+
+            testSubject.enable();
+
+            expect(testSubject.disabled).toBeFalse();
+            expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeFalse();
         });
     });
 });

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -202,6 +202,7 @@ describe('ActionButton', () => {
             testSubject.disable();
 
             expect(testSubject.disabled).toBeTrue();
+            expect(testSubject.element.hasAttribute('disabled')).toBeTrue();
             expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeTrue();
         });
     });
@@ -214,6 +215,7 @@ describe('ActionButton', () => {
             testSubject.enable();
 
             expect(testSubject.disabled).toBeFalse();
+            expect(testSubject.element.hasAttribute('disabled')).toBeFalse();
             expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeFalse();
         });
     });

--- a/tests/components/ActionButton/ActionButton.spec.ts
+++ b/tests/components/ActionButton/ActionButton.spec.ts
@@ -4,8 +4,6 @@ import { ActionButton, IActionButtonOptions } from '../../../src/components/Acti
 import * as icons from '../../../src/utils/icons';
 
 describe('ActionButton', () => {
-    const CoveoDisabledClass = 'coveo-disabled';
-
     let sandbox: SinonSandbox;
     let options: IActionButtonOptions;
     let testSubject: ActionButton;
@@ -66,28 +64,10 @@ describe('ActionButton', () => {
             testSubject = createActionButton(options);
         });
 
-        describe('if disabled', () => {
-            beforeEach(() => {
-                testSubject.disabled = true;
-            });
+        it('should call the handler when clicking the button', () => {
+            testSubject.element.dispatchEvent(new Event('click', {}));
 
-            it('should not call the handler when clicking the button', () => {
-                testSubject.element.dispatchEvent(new Event('click', {}));
-
-                expect(clickHandlerSpy.called).toBeFalse();
-            });
-        });
-
-        describe('if enabled', () => {
-            beforeEach(() => {
-                testSubject.disabled = false;
-            });
-
-            it('should call the handler when clicking the button', () => {
-                testSubject.element.dispatchEvent(new Event('click', {}));
-
-                expect(clickHandlerSpy.called).toBeTrue();
-            });
+            expect(clickHandlerSpy.called).toBeTrue();
         });
     });
 
@@ -191,32 +171,6 @@ describe('ActionButton', () => {
                 const actual = testSubject.element.querySelector(testCase.expectedSelector);
                 expect(actual).toBeDefined();
             });
-        });
-    });
-
-    describe('disable', () => {
-        it(`should add the CSS class ${CoveoDisabledClass} and set the property disabled to true`, () => {
-            testSubject.disabled = false;
-            testSubject.element.classList.remove(CoveoDisabledClass);
-
-            testSubject.disable();
-
-            expect(testSubject.disabled).toBeTrue();
-            expect(testSubject.element.hasAttribute('disabled')).toBeTrue();
-            expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeTrue();
-        });
-    });
-
-    describe('enable', () => {
-        it(`should add the CSS class ${CoveoDisabledClass} and set the property disabled to true`, () => {
-            testSubject.disabled = true;
-            testSubject.element.classList.add(CoveoDisabledClass);
-
-            testSubject.enable();
-
-            expect(testSubject.disabled).toBeFalse();
-            expect(testSubject.element.hasAttribute('disabled')).toBeFalse();
-            expect(testSubject.element.classList.contains(CoveoDisabledClass)).toBeFalse();
         });
     });
 });


### PR DESCRIPTION
ActionButtons can now be disabled

When an ActionButton is disabled:
- It cannot be interacted by the user (hover, focus, click)
- Its styling changes:
![image](https://user-images.githubusercontent.com/12366410/87568810-3da67500-c694-11ea-9f5b-6c660d6f4cbb.png)


UT, SAN-Checked.