### PR TITLE
Fix/SFINT-3352: Ensure internal state is updated first.

### DIFF
--- a/src/components/ActionButton/StatefulActionButton.ts
+++ b/src/components/ActionButton/StatefulActionButton.ts
@@ -93,11 +93,12 @@ export class StatefulActionButton {
             );
             return;
         }
-        this.currentState.onStateExit?.apply(this);
-        state.onStateEntry?.apply(this);
+        const [oldStateExit, newStateEntry] = [this.currentState.onStateExit, state.onStateEntry];
         this.innerActionButton.updateIcon(state.icon);
         this.innerActionButton.updateTooltip(state.tooltip);
         this.currentState = state;
+        oldStateExit?.call(this);
+        newStateEntry?.call(this);
     }
 
     /**

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -192,5 +192,44 @@ describe('ToggleActionButton', () => {
                 });
             });
         });
+
+        describe(`if deactivated triggers an event that would deactivate the button. `, () => {
+            const deactivateEvent = 'deactivate-event';
+            beforeEach(() => {
+                const deactivateWithEvent: (this: ToggleActionButton) => void = function () {
+                    this.element.dispatchEvent(new CustomEvent(deactivateEvent));
+                };
+                activateSpy = sandbox.spy(deactivateWithEvent);
+                options.deactivate = deactivateWithEvent;
+                testSubject = createToggleButton(options);
+                testSubject.element.addEventListener(deactivateEvent, () => {
+                    testSubject.setActivated(false);
+                });
+            });
+
+            describe('if already deactivated', () => {
+                beforeEach(() => {
+                    testSubject.setActivated(false);
+                    sandbox.reset();
+                });
+
+                it('should not call switchTo when setActivated is called with false', () => {
+                    testSubject.setActivated(false);
+                    expect(switchToSpy.called).toBeFalse();
+                });
+            });
+
+            describe('if activated', () => {
+                beforeEach(() => {
+                    testSubject.setActivated(true);
+                    sandbox.reset();
+                });
+
+                it('should call switchTo only once when setActivated is called with false', () => {
+                    testSubject.setActivated(false);
+                    expect(switchToSpy.calledOnce).toBeTrue();
+                });
+            });
+        });
     });
 });

--- a/tests/components/ActionButton/ToggleActionButton.spec.ts
+++ b/tests/components/ActionButton/ToggleActionButton.spec.ts
@@ -5,6 +5,7 @@ import * as icons from '../../../src/utils/icons';
 import { ActionButton } from '../../../src/components/ActionButton/ActionButton';
 import { IComponentOptions } from 'coveo-search-ui';
 import { IToggleableButtonOptions } from '../../../src/components/ActionButton/ToggleableButton';
+import { StatefulActionButton } from '../../../src/components/ActionButton/StatefulActionButton';
 
 describe('ToggleActionButton', () => {
     let sandbox: SinonSandbox;
@@ -16,6 +17,7 @@ describe('ToggleActionButton', () => {
     let deactivateSpy: SinonSpy;
     let updateIconSpy: SinonSpy;
     let updateTooltipSpy: SinonSpy;
+    let switchToSpy: SinonSpy;
 
     beforeAll(() => {
         sandbox = createSandbox();
@@ -25,6 +27,7 @@ describe('ToggleActionButton', () => {
         deactivateSpy = sandbox.spy();
         updateIconSpy = sandbox.spy(<any>ActionButton.prototype, 'updateIcon');
         updateTooltipSpy = sandbox.spy(<any>ActionButton.prototype, 'updateTooltip');
+        switchToSpy = sandbox.spy(<any>StatefulActionButton.prototype, 'switchTo');
     });
 
     beforeEach(() => {
@@ -148,6 +151,45 @@ describe('ToggleActionButton', () => {
                 const option = getOption(current);
 
                 expect(option.alias).toContain(legacy);
+            });
+        });
+
+        describe(`if activated triggers an event that would activate the button. `, () => {
+            const activateEvent = 'activate-event';
+            beforeEach(() => {
+                const activateWithEvent: (this: ToggleActionButton) => void = function () {
+                    this.element.dispatchEvent(new CustomEvent(activateEvent));
+                };
+                activateSpy = sandbox.spy(activateWithEvent);
+                options.activate = activateWithEvent;
+                testSubject = createToggleButton(options);
+                testSubject.element.addEventListener(activateEvent, () => {
+                    testSubject.setActivated(true);
+                });
+            });
+
+            describe('if already activated', () => {
+                beforeEach(() => {
+                    testSubject.setActivated(true);
+                    sandbox.reset();
+                });
+
+                it('should not call switchTo when setActivated is called with true', () => {
+                    testSubject.setActivated(true);
+                    expect(switchToSpy.called).toBeFalse();
+                });
+            });
+
+            describe('if not activated', () => {
+                beforeEach(() => {
+                    testSubject.setActivated(false);
+                    sandbox.reset();
+                });
+
+                it('should call switchTo only once when setActivated is called with true', () => {
+                    testSubject.setActivated(true);
+                    expect(switchToSpy.calledOnce).toBeTrue();
+                });
             });
         });
     });


### PR DESCRIPTION
# What was going on.
![image](https://user-images.githubusercontent.com/12366410/88629557-67d93900-d07d-11ea-8734-82d8b7f3c600.png)

# Fix

Ensure the inner state is updated first, so `activated` is true the first time after the first `setActivated(true)` and therefore the second is no-opped.

This is 'suffisant' as a fix, however, as the Panel also has a state, it's supposed to do the same checks and to update its inner states ASAP in the execution, or at the very least before doing any 'outside' communications.

This will be done in a future PR.

# How was it tested.

SAN Check in SFINT
UT for new code
UT for this peculiar scenarii.

Both UT suites have been tested with and without the changeset, they do fail properly when the fix is not there ✔️ 