### PR TITLE
test(SFINT-3352): Safer tests

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -71,3 +71,20 @@ export function fakeUserProfileModel(root: HTMLElement, sandbox: SinonSandbox) {
     (root as any)[`Coveo${UserProfileModel.ID}`] = sandbox.createStubInstance(UserProfileModel);
     return (root as any)[`Coveo${UserProfileModel.ID}`];
 }
+
+/**
+ * Create a deferred promise
+ */
+export function defer<T = void>() {
+    let resolve: (arg?: T) => void;
+    let reject: (arg: any) => void;
+    const promise = new Promise<T>((p_resolve, p_reject) => {
+        resolve = p_resolve;
+        reject = p_reject;
+    });
+    return {
+        resolve,
+        reject,
+        promise,
+    };
+}


### PR DESCRIPTION
Flaky UT issue from #86, see https://travis-ci.org/github/coveo/search-ui-extensions/builds/712557300.

I was not able to 'pin-point' with certitude what caused the flakiness, due to the issue being, well flaky (and thus I'm not 💯 confident it'll be fixed but I think it will)

Two fixes:
 - Do not modify `activateSpy` and `deactivateSpy` they're used as default options for the component instantiation, which can cause test leakage.
 - Ensure all events listener have completed their job before checking the spies. This also prevents test leakage (you could have the eventListener of the test n-1 executed during the execution of the test n) and also that we're actually testing what we want. (We do not want to 'miss' a double call because the second call occurs after the expectation.