### PR TITLE
feat(SFINT-4388) no results text when no user actions

### DIFF
--- a/src/components/UserActions/Strings.ts
+++ b/src/components/UserActions/Strings.ts
@@ -1,7 +1,13 @@
 import { Translation, Language } from '../../utils/translation';
 
 Translation.register(Language.English, {
-    UserActions_no_actions: 'No actions available for this user',
+    UserActions: 'User Actions',
+    UserActions_no_actions_title: 'No actions available for this user',
+    UserActions_no_actions_causes_title: 'Potential causes',
+    UserActions_no_actions_cause_not_enabled: 'User actions are not enabled',
+    UserActions_no_actions_cause_not_associated: 'There are no user actions associated with the user',
+    UserActions_no_actions_cause_case_too_old: 'The case is too old to detect related actions',
+    UserActions_no_actions_contact_admin: 'Contact your administrator for help',
     UserActions_enable_prompt: 'The User Action feature is not activated for your organization.\nTo activate it, contact Coveo Support.',
 
     QueryList_more: 'Show More',

--- a/src/components/UserActions/Strings.ts
+++ b/src/components/UserActions/Strings.ts
@@ -4,7 +4,7 @@ Translation.register(Language.English, {
     UserActions: 'User Actions',
     UserActions_no_actions_title: 'No actions available for this user',
     UserActions_no_actions_causes_title: 'Potential causes',
-    UserActions_no_actions_cause_not_enabled: 'User actions are not enabled',
+    UserActions_no_actions_cause_not_enabled: 'User actions are not enabled for your organization',
     UserActions_no_actions_cause_not_associated: 'There are no user actions associated with the user',
     UserActions_no_actions_cause_case_too_old: 'The case is too old to detect related actions',
     UserActions_no_actions_contact_admin: 'Contact your administrator for help',

--- a/src/components/UserActions/UserActions.scss
+++ b/src/components/UserActions/UserActions.scss
@@ -52,8 +52,24 @@ $clickable-blue: #004990;
     }
 
     .coveo-no-actions {
-        padding: 3em;
-        text-align: center;
+        padding: 1em;
+        border: 1px solid #b5c4cf;
+        border-radius: 2px;
+        background-color: #f7f8f9;
+        height: 15rem;
+        text-align: left;
+
+        .coveo-user-actions-title {
+            font-size: 1.2em;
+            font-weight: bold;
+            text-align: left;
+            width: auto;
+            margin-bottom: 1em;
+        }
+
+        .coveo-no-actions-causes {
+            margin: 0.5em 0;
+        }
     }
 
     .coveo-enable-prompt {

--- a/src/components/UserActions/UserActions.scss
+++ b/src/components/UserActions/UserActions.scss
@@ -53,9 +53,9 @@ $clickable-blue: #004990;
 
     .coveo-no-actions {
         padding: 1em;
-        border: 1px solid #b5c4cf;
+        border: 1px solid $heather;
         border-radius: 2px;
-        background-color: #f7f8f9;
+        background-color: $background-color-grey;
         height: 15rem;
         text-align: left;
 

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -315,9 +315,9 @@ export class UserActions extends Component {
     }
 
     private renderNoActions() {
-        const element = document.createElement('div');
-        element.classList.add('coveo-no-actions');
-        element.innerHTML = `
+        const messageContainer = document.createElement('div');
+        messageContainer.classList.add('coveo-no-actions');
+        messageContainer.innerHTML = `
         <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
         <div>${l(UserActions.ID + '_no_actions_title')}.</div>
         <br/>
@@ -332,13 +332,13 @@ export class UserActions extends Component {
         `;
 
         this.element.innerHTML = '';
-        this.element.appendChild(element);
+        this.element.appendChild(messageContainer);
     }
 
     private renderEnablePrompt() {
-        const element = document.createElement('div');
-        element.classList.add('coveo-no-actions');
-        element.innerHTML = `
+        const messageContainer = document.createElement('div');
+        messageContainer.classList.add('coveo-no-actions');
+        messageContainer.innerHTML = `
         <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
         <div>${l(UserActions.ID + '_no_actions_cause_not_enabled')}.</div>
         <br/>
@@ -346,7 +346,7 @@ export class UserActions extends Component {
         `;
 
         this.element.innerHTML = '';
-        this.element.appendChild(element);
+        this.element.appendChild(messageContainer);
     }
 
     private showViewedByCustomer() {

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -319,16 +319,15 @@ export class UserActions extends Component {
         messageContainer.classList.add('coveo-no-actions');
         messageContainer.innerHTML = `
         <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
-        <div>${l(UserActions.ID + '_no_actions_title')}.</div>
-        <br/>
-        <div>${l(UserActions.ID + '_no_actions_causes_title')}
+        <p>${l(UserActions.ID + '_no_actions_title')}.</p>
+        <div>
+            <span>${l(UserActions.ID + '_no_actions_causes_title')}</span>
             <ul class="coveo-no-actions-causes">
                 <li>${l(UserActions.ID + '_no_actions_cause_not_associated')}</li>
                 <li>${l(UserActions.ID + '_no_actions_cause_case_too_old')}</li>
             </ul>
         </div>
-        <br/>
-        <div>${l(UserActions.ID + '_no_actions_contact_admin')}.</div>
+        <p>${l(UserActions.ID + '_no_actions_contact_admin')}.</p>
         `;
 
         this.element.innerHTML = '';
@@ -340,9 +339,8 @@ export class UserActions extends Component {
         messageContainer.classList.add('coveo-no-actions');
         messageContainer.innerHTML = `
         <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
-        <div>${l(UserActions.ID + '_no_actions_cause_not_enabled')}.</div>
-        <br/>
-        <div>${l(UserActions.ID + '_no_actions_contact_admin')}.</div>
+        <p>${l(UserActions.ID + '_no_actions_cause_not_enabled')}.</p>
+        <p>${l(UserActions.ID + '_no_actions_contact_admin')}.</p>
         `;
 
         this.element.innerHTML = '';

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -323,8 +323,8 @@ export class UserActions extends Component {
         <div>
             <span>${l(UserActions.ID + '_no_actions_causes_title')}</span>
             <ul class="coveo-no-actions-causes">
-                <li>${l(UserActions.ID + '_no_actions_cause_not_associated')}</li>
-                <li>${l(UserActions.ID + '_no_actions_cause_case_too_old')}</li>
+                <li>${l(UserActions.ID + '_no_actions_cause_not_associated')}.</li>
+                <li>${l(UserActions.ID + '_no_actions_cause_case_too_old')}.</li>
             </ul>
         </div>
         <p>${l(UserActions.ID + '_no_actions_contact_admin')}.</p>

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -175,7 +175,6 @@ export class UserActions extends Component {
             this.element.dispatchEvent(new CustomEvent(UserActions.Events.Show));
             this.bindings.usageAnalytics.logCustomEvent(UserActionEvents.open, {}, this.element);
             this.root.classList.add(UserActions.USER_ACTION_OPENED);
-
             try {
                 const userActions = await (get(this.root, UserProfileModel) as UserProfileModel).getActions(this.options.userId);
                 if (userActions.length > 0) {
@@ -320,19 +319,17 @@ export class UserActions extends Component {
         element.classList.add('coveo-no-actions');
         element.innerHTML = `
         <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
-        <div>${l(UserActions.ID + '_no_actions_title')}</div>
+        <div>${l(UserActions.ID + '_no_actions_title')}.</div>
         <br/>
         <div>${l(UserActions.ID + '_no_actions_causes_title')}
             <ul class="coveo-no-actions-causes">
-                <li>${l(UserActions.ID + '_no_actions_cause_not_enabled')}</li>
                 <li>${l(UserActions.ID + '_no_actions_cause_not_associated')}</li>
                 <li>${l(UserActions.ID + '_no_actions_cause_case_too_old')}</li>
             </ul>
         </div>
         <br/>
-        <div>${l(UserActions.ID + '_no_actions_contact_admin')}</div>
+        <div>${l(UserActions.ID + '_no_actions_contact_admin')}.</div>
         `;
-        // element.innerText = l(`${UserActions.ID}_no_actions_title`);
 
         this.element.innerHTML = '';
         this.element.appendChild(element);
@@ -340,8 +337,13 @@ export class UserActions extends Component {
 
     private renderEnablePrompt() {
         const element = document.createElement('div');
-        element.classList.add('coveo-enable-prompt');
-        element.innerText = l(`${UserActions.ID}_enable_prompt`);
+        element.classList.add('coveo-no-actions');
+        element.innerHTML = `
+        <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
+        <div>${l(UserActions.ID + '_no_actions_cause_not_enabled')}.</div>
+        <br/>
+        <div>${l(UserActions.ID + '_no_actions_contact_admin')}.</div>
+        `;
 
         this.element.innerHTML = '';
         this.element.appendChild(element);

--- a/src/components/UserActions/UserActions.ts
+++ b/src/components/UserActions/UserActions.ts
@@ -318,7 +318,21 @@ export class UserActions extends Component {
     private renderNoActions() {
         const element = document.createElement('div');
         element.classList.add('coveo-no-actions');
-        element.innerText = l(`${UserActions.ID}_no_actions`);
+        element.innerHTML = `
+        <div class="coveo-user-actions-title">${l(UserActions.ID)}</div>
+        <div>${l(UserActions.ID + '_no_actions_title')}</div>
+        <br/>
+        <div>${l(UserActions.ID + '_no_actions_causes_title')}
+            <ul class="coveo-no-actions-causes">
+                <li>${l(UserActions.ID + '_no_actions_cause_not_enabled')}</li>
+                <li>${l(UserActions.ID + '_no_actions_cause_not_associated')}</li>
+                <li>${l(UserActions.ID + '_no_actions_cause_case_too_old')}</li>
+            </ul>
+        </div>
+        <br/>
+        <div>${l(UserActions.ID + '_no_actions_contact_admin')}</div>
+        `;
+        // element.innerText = l(`${UserActions.ID}_no_actions_title`);
 
         this.element.innerHTML = '';
         this.element.appendChild(element);

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -298,6 +298,8 @@ describe('UserActions', () => {
 
         expect(noActions).not.toBeNull();
         expect(noActions.innerText).toContain(l(`${UserActions.ID}_no_actions_title`));
+        expect(noActions.innerText).toContain(l(`${UserActions.ID}_no_actions_cause_not_associated`));
+        expect(noActions.innerText).toContain(l(`${UserActions.ID}_no_actions_cause_case_too_old`));
     });
 
     it('should show a message when actions cannot be gathered', async () => {

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -293,7 +293,7 @@ describe('UserActions', () => {
             })
         );
         await mock.cmp.show();
-        
+
         const noActions = mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions');
 
         expect(noActions).not.toBeNull();

--- a/tests/components/UserActions/UserActions.spec.ts
+++ b/tests/components/UserActions/UserActions.spec.ts
@@ -276,9 +276,9 @@ describe('UserActions', () => {
         );
         await mock.cmp.show();
 
-        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-enable-prompt')).not.toBeNull();
-        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-enable-prompt').innerText).toBe(
-            l(`${UserActions.ID}_enable_prompt`).replace('\n', '')
+        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions')).not.toBeNull();
+        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions').innerText).toContain(
+            l(`${UserActions.ID}_no_actions_cause_not_enabled`)
         );
     });
 
@@ -293,9 +293,11 @@ describe('UserActions', () => {
             })
         );
         await mock.cmp.show();
+        
+        const noActions = mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions');
 
-        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions')).not.toBeNull();
-        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions').innerText).toBe(l(`${UserActions.ID}_no_actions`));
+        expect(noActions).not.toBeNull();
+        expect(noActions.innerText).toContain(l(`${UserActions.ID}_no_actions_title`));
     });
 
     it('should show a message when actions cannot be gathered', async () => {
@@ -310,7 +312,8 @@ describe('UserActions', () => {
         );
         await mock.cmp.show();
 
-        expect(mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions').innerText).toBe(l(`${UserActions.ID}_no_actions`));
+        const messageEl = mock.cmp.element.querySelector<HTMLElement>('.coveo-no-actions');
+        expect(messageEl.innerText).toContain(l(`${UserActions.ID}_no_actions_title`));
     });
 
     describe('when the accordion header is clicked', () => {


### PR DESCRIPTION
New way of explaining why there are no user actions visible.

Where the user actions are not enabled (404 response) :
![image](https://user-images.githubusercontent.com/2488155/152438720-d848fc75-b521-4e94-be3e-9c0f3e0dbb45.png)

When we get an error or no user actions:
![image](https://user-images.githubusercontent.com/2488155/152438757-33d0a297-a955-4c9e-9a86-32994ca58702.png)

