### PR TITLE
feat(sfint-4354) custom events filtering

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -9,7 +9,7 @@
         "moduleResolution": "node",
         "sourceMap": true,
         "skipLibCheck": true,
-        "lib": ["es2015", "dom", "es2018.promise"],
+        "lib": ["es2015", "es2016", "dom", "es2018.promise"],
         "outDir": "../bin/es6",
         "declaration": true,
         "declarationDir": "../bin/typings",

--- a/src/components/UserActions/Strings.ts
+++ b/src/components/UserActions/Strings.ts
@@ -3,7 +3,7 @@ import { Translation, Language } from '../../utils/translation';
 Translation.register(Language.English, {
     UserActions: 'User Actions',
     UserActions_no_actions_title: 'No actions available for this user',
-    UserActions_no_actions_causes_title: 'Potential causes',
+    UserActions_no_actions_causes_title: 'Possible causes',
     UserActions_no_actions_cause_not_enabled: 'User actions are not enabled for your organization',
     UserActions_no_actions_cause_not_associated: 'There are no user actions associated with the user',
     UserActions_no_actions_cause_case_too_old: 'The case is too old to detect related actions',

--- a/src/components/UserActions/Strings.ts
+++ b/src/components/UserActions/Strings.ts
@@ -23,6 +23,8 @@ Translation.register(Language.English, {
     UserActivity_duration: 'Duration',
     UserActivity_other_event: 'Other Event',
     UserActivity_other_events: 'Other Events',
+    UserActivity_no_actions_timeline: 'No actions to display in the timeline',
+    UserActivity_no_actions_cause_filtered: 'All the actions were filtered',
 
     UserActivity_search: 'Query',
     UserActivity_query: 'User Query',

--- a/src/components/UserActions/UserActivity.ts
+++ b/src/components/UserActions/UserActivity.ts
@@ -107,12 +107,6 @@ export class UserActivity extends Component {
         this.userProfileModel = get(this.root, UserProfileModel) as UserProfileModel;
 
         this.userProfileModel.getActions(this.options.userId).then((actions) => {
-            const FAKE_EVENT_CUSTOM = new UserAction(UserActionType.Custom, new Date(), {
-                event_type: 'ticket_field_update',
-                event_value: 'caseDetach',
-                origin_level_1: 'foo',
-            });
-            actions = [FAKE_EVENT_CUSTOM];
             const sortMostRecentFirst = (a: UserAction, b: UserAction) => b.timestamp.getTime() - a.timestamp.getTime();
             const sortedActions = actions.sort(sortMostRecentFirst);
 

--- a/src/components/UserActions/UserActivity.ts
+++ b/src/components/UserActions/UserActivity.ts
@@ -108,11 +108,11 @@ export class UserActivity extends Component {
 
         this.userProfileModel.getActions(this.options.userId).then((actions) => {
             const sortMostRecentFirst = (a: UserAction, b: UserAction) => b.timestamp.getTime() - a.timestamp.getTime();
-            const sortedActions = actions.sort(sortMostRecentFirst);
+            const sortedActions = [...actions].sort(sortMostRecentFirst);
 
             let filteredActions = sortedActions;
             if (this.options.customActionsExclude && this.options.customActionsExclude.length > 0) {
-                filteredActions = actions.filter((action) => this.filterActions(action));
+                filteredActions = sortedActions.filter((action) => this.filterActions(action));
             }
             this.sessions = this.splitActionsBySessions(filteredActions);
 
@@ -132,16 +132,13 @@ export class UserActivity extends Component {
     }
 
     private filterActions(action: UserAction): boolean {
+        return action.type !== UserActionType.Custom || !this.shouldExcludeCustomAction(action);
+    }
+
+    private shouldExcludeCustomAction(action: UserAction): boolean {
         const eventValue = action.raw.event_value || '';
         const eventType = action.raw.event_type || '';
-        if (action.type === UserActionType.Custom) {
-            return (
-                action.type === UserActionType.Custom &&
-                !this.options.customActionsExclude.includes(eventValue) &&
-                !this.options.customActionsExclude.includes(eventType)
-            );
-        }
-        return true;
+        return this.options.customActionsExclude.includes(eventValue) || this.options.customActionsExclude.includes(eventType);
     }
 
     private isPartOfTheSameSession = (action: UserAction, previousDateTime: Date): boolean => {


### PR DESCRIPTION
#nofilter
![image](https://user-images.githubusercontent.com/2488155/153079360-4f4b5c7d-47d6-490b-bc9f-e04e360b9f91.png)

#withfilter 
![image](https://user-images.githubusercontent.com/2488155/153079384-321ac91a-f93c-482c-82e2-af961f2a87a8.png)

#withallactionsfiltered
![image](https://user-images.githubusercontent.com/2488155/153079421-0726eb36-e139-45d9-85b5-7cae797bcb73.png)


Don't think the third case is actually possible but I thought I still needed to include it.