### PR TITLE
chore(npm): put jsui as prodDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
     "name": "coveo-search-ui-extensions",
-    "version": "0.0.5",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "coveo-search-ui-extensions",
-            "version": "0.0.5",
+            "version": "0.1.0",
             "license": "Apache-2.0",
+            "dependencies": {
+                "coveo-search-ui": "^2.10089.4"
+            },
             "devDependencies": {
                 "@cypress/webpack-preprocessor": "^4.1.2",
                 "@types/chai": "^4.2.9",
@@ -15,7 +18,6 @@
                 "@types/mocha": "^7.0.1",
                 "@types/node": "^11.11.3",
                 "@types/sinon": "^7.0.13",
-                "coveo-search-ui": "^2.10089.4",
                 "coveo-search-ui-tests": "0.0.7",
                 "coveralls": "^3.0.3",
                 "cypress": "^4.12.1",
@@ -1647,7 +1649,6 @@
             "version": "7.16.8",
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz",
             "integrity": "sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==",
-            "dev": true,
             "dependencies": {
                 "core-js-pure": "^3.20.2",
                 "regenerator-runtime": "^0.13.4"
@@ -1659,8 +1660,7 @@
         "node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
             "version": "0.13.9",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-            "dev": true
+            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
         "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
             "version": "0.13.9",
@@ -4073,7 +4073,6 @@
             "version": "3.20.3",
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.3.tgz",
             "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==",
-            "dev": true,
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -4090,7 +4089,6 @@
             "version": "2.10089.4",
             "resolved": "https://registry.npmjs.org/coveo-search-ui/-/coveo-search-ui-2.10089.4.tgz",
             "integrity": "sha512-YCwXbgcW4uVfJAoDLQRMuIJvEOvJ1qTeuGmeVK20KJR725+G41mnErxeOJHwlQcsvPjt9ziMZMPfkfSoMzl4Cw==",
-            "dev": true,
             "dependencies": {
                 "coveo.analytics": "^0.7.0",
                 "d3": "^4.2.1",
@@ -4123,7 +4121,6 @@
             "version": "2.22.2",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
             "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -4132,7 +4129,6 @@
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-0.7.4.tgz",
             "integrity": "sha512-TEnmCh2Qs8vWjliTlJO1sAEVvQu1ARMd/xEEhrZEkgfqWIRN6xioOVSnO/6XdgEj9B+CSpKUk3g/ATPSDcndjg==",
-            "dev": true,
             "dependencies": {
                 "whatwg-fetch": "^2.0.0"
             }
@@ -4444,7 +4440,6 @@
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
             "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
-            "dev": true,
             "dependencies": {
                 "d3-array": "1.2.1",
                 "d3-axis": "1.0.8",
@@ -4481,20 +4476,17 @@
         "node_modules/d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
-            "dev": true
+            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "node_modules/d3-axis": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo=",
-            "dev": true
+            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
         },
         "node_modules/d3-brush": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
             "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
-            "dev": true,
             "dependencies": {
                 "d3-dispatch": "1",
                 "d3-drag": "1",
@@ -4507,7 +4499,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
             "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
-            "dev": true,
             "dependencies": {
                 "d3-array": "1",
                 "d3-path": "1"
@@ -4516,26 +4507,22 @@
         "node_modules/d3-collection": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI=",
-            "dev": true
+            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
         },
         "node_modules/d3-color": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
-            "dev": true
+            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
         },
         "node_modules/d3-dispatch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg=",
-            "dev": true
+            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
         },
         "node_modules/d3-drag": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
             "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
-            "dev": true,
             "dependencies": {
                 "d3-dispatch": "1",
                 "d3-selection": "1"
@@ -4545,7 +4532,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
             "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
-            "dev": true,
             "dependencies": {
                 "commander": "2",
                 "iconv-lite": "0.4",
@@ -4566,20 +4552,17 @@
         "node_modules/d3-dsv/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/d3-ease": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4=",
-            "dev": true
+            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
         },
         "node_modules/d3-force": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
             "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
-            "dev": true,
             "dependencies": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -4590,14 +4573,12 @@
         "node_modules/d3-format": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw==",
-            "dev": true
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
         },
         "node_modules/d3-geo": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
             "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
-            "dev": true,
             "dependencies": {
                 "d3-array": "1"
             }
@@ -4605,14 +4586,12 @@
         "node_modules/d3-hierarchy": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY=",
-            "dev": true
+            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
         },
         "node_modules/d3-interpolate": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
             "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
-            "dev": true,
             "dependencies": {
                 "d3-color": "1"
             }
@@ -4620,38 +4599,32 @@
         "node_modules/d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
-            "dev": true
+            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
         },
         "node_modules/d3-polygon": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI=",
-            "dev": true
+            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
         },
         "node_modules/d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg=",
-            "dev": true
+            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
         },
         "node_modules/d3-queue": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg=",
-            "dev": true
+            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg="
         },
         "node_modules/d3-random": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM=",
-            "dev": true
+            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
         },
         "node_modules/d3-request": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
             "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "dev": true,
             "dependencies": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -4663,7 +4636,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
             "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-            "dev": true,
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -4677,14 +4649,12 @@
         "node_modules/d3-selection": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA==",
-            "dev": true
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "node_modules/d3-shape": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
             "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
-            "dev": true,
             "dependencies": {
                 "d3-path": "1"
             }
@@ -4692,14 +4662,12 @@
         "node_modules/d3-time": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ==",
-            "dev": true
+            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
         "node_modules/d3-time-format": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
             "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-            "dev": true,
             "dependencies": {
                 "d3-time": "1"
             }
@@ -4707,14 +4675,12 @@
         "node_modules/d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==",
-            "dev": true
+            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
         },
         "node_modules/d3-transition": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
             "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "dev": true,
             "dependencies": {
                 "d3-color": "1",
                 "d3-dispatch": "1",
@@ -4727,14 +4693,12 @@
         "node_modules/d3-voronoi": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
-            "dev": true
+            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
         },
         "node_modules/d3-zoom": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
             "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
-            "dev": true,
             "dependencies": {
                 "d3-dispatch": "1",
                 "d3-drag": "1",
@@ -5291,8 +5255,7 @@
         "node_modules/es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
@@ -5637,8 +5600,7 @@
         "node_modules/exponential-backoff": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-2.2.1.tgz",
-            "integrity": "sha512-53+Tl7I7mJMDHf90mAZR8t1cg+7IKgx/W5p46tOfuIE9EWqPbyCMIvGk4bhcSE2w5AWO8YmEhLj7qYfxyo/2rQ==",
-            "dev": true
+            "integrity": "sha512-53+Tl7I7mJMDHf90mAZR8t1cg+7IKgx/W5p46tOfuIE9EWqPbyCMIvGk4bhcSE2w5AWO8YmEhLj7qYfxyo/2rQ=="
         },
         "node_modules/express": {
             "version": "4.17.2",
@@ -6784,7 +6746,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -7839,8 +7800,7 @@
         "node_modules/jstimezonedetect": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.7.tgz",
-            "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ==",
-            "dev": true
+            "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ=="
         },
         "node_modules/just-extend": {
             "version": "4.2.1",
@@ -8082,8 +8042,7 @@
         "node_modules/latinize": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/latinize/-/latinize-0.4.1.tgz",
-            "integrity": "sha512-A4miz97dNF+EbNgQdayPAEtud5eRpCGPwJy7JQFD1hBQcOzOgBS4m721zoREuPqpz1yKm8hYT2ANlh7pirapsA==",
-            "dev": true
+            "integrity": "sha512-A4miz97dNF+EbNgQdayPAEtud5eRpCGPwJy7JQFD1hBQcOzOgBS4m721zoREuPqpz1yKm8hYT2ANlh7pirapsA=="
         },
         "node_modules/lazy-ass": {
             "version": "1.6.0",
@@ -8826,8 +8785,7 @@
         "node_modules/modal-box": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/modal-box/-/modal-box-2.0.10.tgz",
-            "integrity": "sha1-Rw7WtXkzb5oEHH5y0yNCwQx4uIE=",
-            "dev": true
+            "integrity": "sha1-Rw7WtXkzb5oEHH5y0yNCwQx4uIE="
         },
         "node_modules/moment": {
             "version": "2.29.1",
@@ -9597,8 +9555,7 @@
         "node_modules/pikaday": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.2.tgz",
-            "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew==",
-            "dev": true
+            "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew=="
         },
         "node_modules/pinkie": {
             "version": "2.0.4",
@@ -9639,7 +9596,6 @@
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
             "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-            "dev": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -10454,8 +10410,7 @@
         "node_modules/rw": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-            "dev": true
+            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
         },
         "node_modules/rxjs": {
             "version": "6.6.7",
@@ -10487,8 +10442,7 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sass": {
             "version": "1.49.0",
@@ -12217,8 +12171,7 @@
         "node_modules/underscore": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
-            "dev": true
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -13240,8 +13193,7 @@
         "node_modules/whatwg-fetch": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-            "dev": true
+            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         },
         "node_modules/which": {
             "version": "1.3.1",
@@ -13354,7 +13306,6 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
             "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -13372,7 +13323,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
             "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
-            "dev": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.12.1"
             }
@@ -14667,7 +14617,6 @@
             "version": "7.16.8",
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz",
             "integrity": "sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==",
-            "dev": true,
             "requires": {
                 "core-js-pure": "^3.20.2",
                 "regenerator-runtime": "^0.13.4"
@@ -14676,8 +14625,7 @@
                 "regenerator-runtime": {
                     "version": "0.13.9",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-                    "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-                    "dev": true
+                    "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
                 }
             }
         },
@@ -16695,8 +16643,7 @@
         "core-js-pure": {
             "version": "3.20.3",
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.3.tgz",
-            "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==",
-            "dev": true
+            "integrity": "sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA=="
         },
         "core-util-is": {
             "version": "1.0.3",
@@ -16708,7 +16655,6 @@
             "version": "2.10089.4",
             "resolved": "https://registry.npmjs.org/coveo-search-ui/-/coveo-search-ui-2.10089.4.tgz",
             "integrity": "sha512-YCwXbgcW4uVfJAoDLQRMuIJvEOvJ1qTeuGmeVK20KJR725+G41mnErxeOJHwlQcsvPjt9ziMZMPfkfSoMzl4Cw==",
-            "dev": true,
             "requires": {
                 "coveo.analytics": "^0.7.0",
                 "d3": "^4.2.1",
@@ -16728,8 +16674,7 @@
                 "moment": {
                     "version": "2.22.2",
                     "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-                    "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-                    "dev": true
+                    "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
                 }
             }
         },
@@ -16746,7 +16691,6 @@
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-0.7.4.tgz",
             "integrity": "sha512-TEnmCh2Qs8vWjliTlJO1sAEVvQu1ARMd/xEEhrZEkgfqWIRN6xioOVSnO/6XdgEj9B+CSpKUk3g/ATPSDcndjg==",
-            "dev": true,
             "requires": {
                 "whatwg-fetch": "^2.0.0"
             }
@@ -17017,7 +16961,6 @@
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
             "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
-            "dev": true,
             "requires": {
                 "d3-array": "1.2.1",
                 "d3-axis": "1.0.8",
@@ -17054,20 +16997,17 @@
         "d3-array": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
-            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
-            "dev": true
+            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "d3-axis": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo=",
-            "dev": true
+            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
         },
         "d3-brush": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
             "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
-            "dev": true,
             "requires": {
                 "d3-dispatch": "1",
                 "d3-drag": "1",
@@ -17080,7 +17020,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
             "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
-            "dev": true,
             "requires": {
                 "d3-array": "1",
                 "d3-path": "1"
@@ -17089,26 +17028,22 @@
         "d3-collection": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI=",
-            "dev": true
+            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
         },
         "d3-color": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
-            "dev": true
+            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
         },
         "d3-dispatch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg=",
-            "dev": true
+            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
         },
         "d3-drag": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
             "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
-            "dev": true,
             "requires": {
                 "d3-dispatch": "1",
                 "d3-selection": "1"
@@ -17118,7 +17053,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
             "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
-            "dev": true,
             "requires": {
                 "commander": "2",
                 "iconv-lite": "0.4",
@@ -17128,22 +17062,19 @@
                 "commander": {
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
                 }
             }
         },
         "d3-ease": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4=",
-            "dev": true
+            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
         },
         "d3-force": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
             "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
-            "dev": true,
             "requires": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -17154,14 +17085,12 @@
         "d3-format": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
-            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw==",
-            "dev": true
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
         },
         "d3-geo": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
             "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
-            "dev": true,
             "requires": {
                 "d3-array": "1"
             }
@@ -17169,14 +17098,12 @@
         "d3-hierarchy": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY=",
-            "dev": true
+            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
         },
         "d3-interpolate": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
             "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
-            "dev": true,
             "requires": {
                 "d3-color": "1"
             }
@@ -17184,38 +17111,32 @@
         "d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
-            "dev": true
+            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
         },
         "d3-polygon": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI=",
-            "dev": true
+            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
         },
         "d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg=",
-            "dev": true
+            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
         },
         "d3-queue": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg=",
-            "dev": true
+            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg="
         },
         "d3-random": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM=",
-            "dev": true
+            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
         },
         "d3-request": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
             "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-            "dev": true,
             "requires": {
                 "d3-collection": "1",
                 "d3-dispatch": "1",
@@ -17227,7 +17148,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
             "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-            "dev": true,
             "requires": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -17241,14 +17161,12 @@
         "d3-selection": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
-            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA==",
-            "dev": true
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
         },
         "d3-shape": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
             "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
-            "dev": true,
             "requires": {
                 "d3-path": "1"
             }
@@ -17256,14 +17174,12 @@
         "d3-time": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ==",
-            "dev": true
+            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
         },
         "d3-time-format": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
             "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-            "dev": true,
             "requires": {
                 "d3-time": "1"
             }
@@ -17271,14 +17187,12 @@
         "d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==",
-            "dev": true
+            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
         },
         "d3-transition": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
             "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
-            "dev": true,
             "requires": {
                 "d3-color": "1",
                 "d3-dispatch": "1",
@@ -17291,14 +17205,12 @@
         "d3-voronoi": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
-            "dev": true
+            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
         },
         "d3-zoom": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
             "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
-            "dev": true,
             "requires": {
                 "d3-dispatch": "1",
                 "d3-drag": "1",
@@ -17797,8 +17709,7 @@
         "es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-            "dev": true
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "es6-symbol": {
             "version": "3.1.3",
@@ -18072,8 +17983,7 @@
         "exponential-backoff": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-2.2.1.tgz",
-            "integrity": "sha512-53+Tl7I7mJMDHf90mAZR8t1cg+7IKgx/W5p46tOfuIE9EWqPbyCMIvGk4bhcSE2w5AWO8YmEhLj7qYfxyo/2rQ==",
-            "dev": true
+            "integrity": "sha512-53+Tl7I7mJMDHf90mAZR8t1cg+7IKgx/W5p46tOfuIE9EWqPbyCMIvGk4bhcSE2w5AWO8YmEhLj7qYfxyo/2rQ=="
         },
         "express": {
             "version": "4.17.2",
@@ -19004,7 +18914,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -19826,8 +19735,7 @@
         "jstimezonedetect": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.7.tgz",
-            "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ==",
-            "dev": true
+            "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ=="
         },
         "just-extend": {
             "version": "4.2.1",
@@ -20024,8 +19932,7 @@
         "latinize": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/latinize/-/latinize-0.4.1.tgz",
-            "integrity": "sha512-A4miz97dNF+EbNgQdayPAEtud5eRpCGPwJy7JQFD1hBQcOzOgBS4m721zoREuPqpz1yKm8hYT2ANlh7pirapsA==",
-            "dev": true
+            "integrity": "sha512-A4miz97dNF+EbNgQdayPAEtud5eRpCGPwJy7JQFD1hBQcOzOgBS4m721zoREuPqpz1yKm8hYT2ANlh7pirapsA=="
         },
         "lazy-ass": {
             "version": "1.6.0",
@@ -20615,8 +20522,7 @@
         "modal-box": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/modal-box/-/modal-box-2.0.10.tgz",
-            "integrity": "sha1-Rw7WtXkzb5oEHH5y0yNCwQx4uIE=",
-            "dev": true
+            "integrity": "sha1-Rw7WtXkzb5oEHH5y0yNCwQx4uIE="
         },
         "moment": {
             "version": "2.29.1",
@@ -21254,8 +21160,7 @@
         "pikaday": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.2.tgz",
-            "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew==",
-            "dev": true
+            "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew=="
         },
         "pinkie": {
             "version": "2.0.4",
@@ -21285,8 +21190,7 @@
         "popper.js": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-            "dev": true
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
         },
         "portfinder": {
             "version": "1.0.28",
@@ -21962,8 +21866,7 @@
         "rw": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-            "dev": true
+            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
         },
         "rxjs": {
             "version": "6.6.7",
@@ -21992,8 +21895,7 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sass": {
             "version": "1.49.0",
@@ -23449,8 +23351,7 @@
         "underscore": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
-            "dev": true
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -24290,8 +24191,7 @@
         "whatwg-fetch": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-            "dev": true
+            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         },
         "which": {
             "version": "1.3.1",
@@ -24384,8 +24284,7 @@
         "xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-            "dev": true
+            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
         },
         "xmlhttprequest-ssl": {
             "version": "1.5.5",
@@ -24397,7 +24296,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
             "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
-            "dev": true,
             "requires": {
                 "@babel/runtime-corejs3": "^7.12.1"
             }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "@types/mocha": "^7.0.1",
         "@types/node": "^11.11.3",
         "@types/sinon": "^7.0.13",
-        "coveo-search-ui": "^2.10089.4",
         "coveo-search-ui-tests": "0.0.7",
         "coveralls": "^3.0.3",
         "cypress": "^4.12.1",
@@ -92,6 +91,9 @@
         "webpack-dev-server": "^3.11.0",
         "webpack-karma-die-hard": "^1.0.4",
         "xml2js": "^0.4.23"
+    },
+    "dependencies": {
+        "coveo-search-ui": "^2.10089.4"
     },
     "snyk": true
 }


### PR DESCRIPTION
Move jsui to 'prod' dependencies to be semantically accurate because the packages depend on it. (albeit from the browser)

The bundling should be unaffected, given this: 
https://github.com/coveo/search-ui-extensions/blob/master/config/webpack.config.js#L15-L21