### PR TITLE
chore: upgrade xml2js and clean CI env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     workflow_dispatch:
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
     publish:
@@ -22,7 +22,7 @@ jobs:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
               with:
-                egress-policy: audit
+                  egress-policy: audit
 
             - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2
             - name: Use Node.js ${{ matrix.node-version }}
@@ -37,8 +37,6 @@ jobs:
             - run: npm ci
             - run: npm run build
             - run: npm run testCoverage
-              env:
-                  COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
             - run: npm publish --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "webpack": "^4.29.6",
                 "webpack-cli": "^3.2.3",
                 "webpack-dev-server": "^3.11.0",
-                "xml2js": "^0.4.23"
+                "xml2js": "^0.6.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -13863,10 +13863,11 @@
             }
         },
         "node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -24790,9 +24791,9 @@
             }
         },
         "xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "dev": true,
             "requires": {
                 "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "webpack": "^4.29.6",
         "webpack-cli": "^3.2.3",
         "webpack-dev-server": "^3.11.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.6.2"
     },
     "snyk": true,
     "overrides": {


### PR DESCRIPTION
Summary:
- upgrade xml2js from 0.4.23 to 0.6.2
- remove the stale COVERALLS_REPO_TOKEN env wiring from the publish workflow
- refresh the lockfile for the direct dependency bump

Verification:
- npm run build
- npm test
- npx prettier --check .github/workflows/publish.yml package.json package-lock.json

Notes:
This is a small cleanup PR ahead of the larger webpack/Cypress/tooling migration work.